### PR TITLE
Fixed the Customization input field movement bug

### DIFF
--- a/Source/Modules/CardCustomization/View/JPCardCustomizationViewController.m
+++ b/Source/Modules/CardCustomization/View/JPCardCustomizationViewController.m
@@ -187,6 +187,7 @@ const float kCustomizationViewClearGradientLocation = 1.0f;
         JPCardCustomizationTextInputCell *textInputCell;
         textInputCell = (JPCardCustomizationTextInputCell *)cell;
         textInputCell.inputField.delegate = self;
+        [textInputCell configureWithViewModel:selectedModel];
     }
 
     if ([cell isKindOfClass:JPCardCustomizationSubmitCell.class]) {


### PR DESCRIPTION
# Bug Description
- Closing and then reopening the app triggers a layout reset. Transformations are lost in the process.
- Changing card patterns triggers a table view reload. If an input field error is visible, it is not reset and remains visible even if the error cause is no longer present.

# Fixes:
- Listen to the `UIApplicationWillEnterForegroundNotification` event and manually reset the frame back to the correct position.
- Manually reset the font and error state on every table view reload.

# Demo:
https://thedojo.atlassian.net/browse/EP-782