### PR TITLE
Added fix for the invalid ApplePay supported card networks

### DIFF
--- a/Source/Services/ApplePay/JPApplePayService.m
+++ b/Source/Services/ApplePay/JPApplePayService.m
@@ -238,7 +238,7 @@
 
     NSMutableArray<PKPaymentNetwork> *pkPaymentNetworks = [[NSMutableArray alloc] init];
 
-    JPCardNetworkType cardNetworks = self.configuration.supportedCardNetworks;
+    JPCardNetworkType cardNetworks = self.configuration.applePayConfiguration.supportedCardNetworks;
 
     if (cardNetworks && JPCardNetworkTypeVisa) {
         [pkPaymentNetworks addObject:PKPaymentNetworkVisa];


### PR DESCRIPTION
For some reason, the `JPApplePayService` was looking at the main supported card networks that we use for Judo card transactions, instead of the Apple Pay specific supported networks.