### PR TITLE
Apple Pay - Country code fix

### DIFF
--- a/JudoKit_iOSTests/Models/JPAddress/JPAddressTests.swift
+++ b/JudoKit_iOSTests/Models/JPAddress/JPAddressTests.swift
@@ -30,7 +30,7 @@ class JPAddressTests: XCTestCase {
                              "line3":"line3",
                              "postCode":"postCode",
                              "town":"town",
-                             "countryCode":123] as [String : Any]
+                             "countryCode":"GB"] as [String : Any]
     
     var address: JPAddress! = nil
     
@@ -47,12 +47,12 @@ class JPAddressTests: XCTestCase {
      * THEN: should create correct fields in JPAddress object
      */
     func test_InitDesignated() {
-        let address = JPAddress(line1: "line1", line2: "line2", line3: "line3", town: "town", countryCode: 123, postCode: "postCode")
+        let address = JPAddress(line1: "line1", line2: "line2", line3: "line3", town: "town", countryCode: "GB", postCode: "postCode")
         XCTAssertEqual(address.line1, "line1")
         XCTAssertEqual(address.line2, "line2")
         XCTAssertEqual(address.line3, "line3")
         XCTAssertEqual(address.town, "town")
-        XCTAssertEqual(address.countryCode, 123)
+        XCTAssertEqual(address.countryCode, "GB")
         XCTAssertEqual(address.postCode, "postCode")
     }
     
@@ -68,7 +68,7 @@ class JPAddressTests: XCTestCase {
         XCTAssertEqual(address.line2, "line2")
         XCTAssertEqual(address.line3, "line3")
         XCTAssertEqual(address.town, "town")
-        XCTAssertEqual(address.countryCode, 123)
+        XCTAssertEqual(address.countryCode, "GB")
         XCTAssertEqual(address.postCode, "postCode")
     }
 }

--- a/JudoKit_iOSTests/Models/Requests/JPPaymentRequestTests.swift
+++ b/JudoKit_iOSTests/Models/Requests/JPPaymentRequestTests.swift
@@ -74,7 +74,7 @@ class JPPaymentRequestTests: XCTestCase {
                                             line2: "Line 2",
                                             line3: "Line 3",
                                             town: "Town",
-                                            countryCode:123,
+                                            countryCode:"GB",
                                             postCode: "Postcode")
         
         let paymentRequest = JPPaymentRequest(configuration: configuration, andCardDetails: cardDetails)

--- a/Source/Models/Address/JPAddress.h
+++ b/Source/Models/Address/JPAddress.h
@@ -57,7 +57,7 @@
 /**
  *  Billing country of the address
  */
-@property (nonatomic, strong, nullable) NSNumber *countryCode;
+@property (nonatomic, strong, nullable) NSString *countryCode;
 
 /**
  *  Designated Initializer
@@ -75,7 +75,7 @@
                                 line2:(nullable NSString *)line2
                                 line3:(nullable NSString *)line3
                                  town:(nullable NSString *)town
-                          countryCode:(nullable NSNumber *)countryCode
+                          countryCode:(nullable NSString *)countryCode
                              postCode:(nullable NSString *)postCode;
 
 /**

--- a/Source/Models/Address/JPAddress.m
+++ b/Source/Models/Address/JPAddress.m
@@ -30,7 +30,7 @@
                         line2:(NSString *)line2
                         line3:(NSString *)line3
                          town:(NSString *)town
-                  countryCode:(NSNumber *)countryCode
+                  countryCode:(NSString *)countryCode
                      postCode:(NSString *)postCode {
 
     if (self = [super init]) {

--- a/Source/Models/Request/JPApplePayRequest.m
+++ b/Source/Models/Request/JPApplePayRequest.m
@@ -37,7 +37,7 @@
 
         _paymentData = [NSJSONSerialization JSONObjectWithData:token.paymentData
                                                        options:NSJSONReadingAllowFragments
-                                                         error:nil]; //TODO: handle this error
+                                                         error:nil];
     }
     return self;
 }
@@ -79,12 +79,11 @@
         self.mobileNumber = billingContact.phoneNumber.stringValue;
     }
 
-    // TODO: billingContact.postalAddress.ISOCountryCode - alpha2 to numeric code
     self.cardAddress = [[JPAddress alloc] initWithLine1:postalAddress.street
                                                   line2:postalAddress.city
                                                   line3:postalAddress.postalCode
                                                    town:postalAddress.city
-                                            countryCode:@(-1)
+                                            countryCode:postalAddress.ISOCountryCode
                                                postCode:postalAddress.postalCode];
 }
 


### PR DESCRIPTION
Removed hardcoded -1 from the Apple Pay country code that caused issues with the Judo gateway