### PR TITLE
Added fix for locale-specific amount formatting

### DIFF
--- a/Source/Services/ConfigurationValidation/JPConfigurationValidationService.m
+++ b/Source/Services/ConfigurationValidation/JPConfigurationValidationService.m
@@ -131,6 +131,7 @@
 - (void)checkIfAmountIsNumber:(NSString *)amount error:(NSError **)error {
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     formatter.numberStyle = NSNumberFormatterDecimalStyle;
+    formatter.decimalSeparator = @".";
     NSNumber *number = [formatter numberFromString:amount];
     if (!number || number.intValue < 0) {
         *error = JPError.judoInvalidAmountError;


### PR DESCRIPTION
### What happened?
Our amount validation logic was based on NSNumberFormatter. Depending on your current locale, valid decimal separators are perceived as either `0.15` or `0,15`.