### PR TITLE
Handling user cancellation of Apple Pay

### DIFF
--- a/Source/Services/ApplePay/JPApplePayController.m
+++ b/Source/Services/ApplePay/JPApplePayController.m
@@ -67,6 +67,7 @@
 
 - (void)paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller {
     [controller dismissViewControllerAnimated:YES completion:nil];
+    self.completionBlock(nil, [NSError judoUserDidCancelError]);
 }
 
 @end


### PR DESCRIPTION
1. When ever the user manually dismisses apple pay, the event should be passed to the caller via callback
2. This is impacting the React native library 