### PR TITLE
Added a "User Cancelled" callback to Apple Pay

### DIFF
--- a/Source/JudoKit.m
+++ b/Source/JudoKit.m
@@ -44,11 +44,15 @@
 @property (nonatomic, strong) JPApiService *apiService;
 @property (nonatomic, strong) JPApplePayService *applePayService;
 @property (nonatomic, strong) JPApplePayController *applePayController;
+@property (nonatomic, strong) JPCompletionBlock applePayCompletionBlock;
 @property (nonatomic, strong) JPPBBAService *pbbaService;
 @property (nonatomic, strong) JPConfiguration *configuration;
 @property (nonatomic, strong) JPSliderTransitioningDelegate *transitioningDelegate;
 @property (nonatomic, strong) id<JPConfigurationValidationService> configurationValidationService;
 
+@end
+
+@interface JudoKit (JPApplePayDelegate) <JPApplePayControllerDelegate>
 @end
 
 @implementation JudoKit
@@ -151,6 +155,9 @@
                                                               andApiService:self.apiService];
 
     self.applePayController = [[JPApplePayController alloc] initWithConfiguration:configuration];
+    self.applePayController.delegate = self;
+
+    self.applePayCompletionBlock = completion;
 
     UIViewController *controller = [self.applePayController applePayViewControllerWithAuthorizationBlock:^(PKPayment *payment, JPApplePayAuthStatusBlock statusCompletion) {
         [self.applePayService processApplePayment:payment
@@ -244,6 +251,14 @@
 - (void)fetchTransactionWithReceiptId:(nonnull NSString *)receiptId
                            completion:(nullable JPCompletionBlock)completion {
     [self.apiService fetchTransactionWithReceiptId:receiptId completion:completion];
+}
+
+@end
+
+@implementation JudoKit (JPApplePayDelegate)
+
+- (void)applePayControllerDidCancelTransaction:(JPApplePayController *)controller {
+    self.applePayCompletionBlock(nil, JPError.judoUserDidCancelError);
 }
 
 @end

--- a/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
+++ b/Source/Modules/PaymentMethods/Presenter/JPPaymentMethodsPresenter.m
@@ -130,9 +130,9 @@
 }
 
 - (void)handleBackButtonTap {
+    [self.router dismissViewController];
     [self.interactor completeTransactionWithResponse:nil
                                             andError:JPError.judoUserDidCancelError];
-    [self.router dismissViewController];
 }
 
 - (void)handlePayButtonTap {
@@ -197,8 +197,8 @@
     if (selectedCardIndex >= 0) {
         [self.interactor setLastUsedCardAtIndex:selectedCardIndex];
     }
-    [self.interactor completeTransactionWithResponse:response andError:nil];
     [self.router dismissViewController];
+    [self.interactor completeTransactionWithResponse:response andError:nil];
 }
 
 - (void)handlePaymentError:(NSError *)error {
@@ -287,8 +287,8 @@
         [self handlePaymentError:error];
         return;
     }
-    [self.interactor completeTransactionWithResponse:response andError:nil];
     [self.router dismissViewController];
+    [self.interactor completeTransactionWithResponse:response andError:nil];
 }
 
 - (void)handleCallbackWithResponse:(JPResponse *)response

--- a/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
+++ b/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
@@ -205,8 +205,8 @@
 }
 
 - (void)handleCancelButtonTap {
-    [self.interactor completeTransactionWithResponse:nil error:JPError.judoUserDidCancelError];
     [self.router dismissViewController];
+    [self.interactor completeTransactionWithResponse:nil error:JPError.judoUserDidCancelError];
 }
 
 #pragma mark - Helper methods

--- a/Source/Services/ApplePay/JPApplePayController.h
+++ b/Source/Services/ApplePay/JPApplePayController.h
@@ -27,7 +27,26 @@
 
 @class JPConfiguration;
 
+@class JPConfiguration, JPApplePayController;
+
+@protocol JPApplePayControllerDelegate
+
+/**
+ * A method triggered once the user taps on "Cancel" and dismisses the Apple Pay sheet.
+ * Used to notify the merchant of a "User Cancelled" event via the completion block.
+ *
+ * @param controller - a reference to the JPApplePayController
+ */
+- (void)applePayControllerDidCancelTransaction:(nonnull JPApplePayController *)controller;
+
+@end
+
 @interface JPApplePayController : NSObject <PKPaymentAuthorizationViewControllerDelegate>
+
+/**
+ * A weak reference to an object implementing the JPApplePayControllerDelegate protocol
+ */
+@property (nullable, nonatomic, weak) id<JPApplePayControllerDelegate> delegate;
 
 /**
  * Designated initalizer that creates a configured instance of JPApplePayController for making Apple Pay transactions.

--- a/Source/Services/ApplePay/JPApplePayController.m
+++ b/Source/Services/ApplePay/JPApplePayController.m
@@ -67,6 +67,7 @@
 
 - (void)paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller {
     [controller dismissViewControllerAnimated:YES completion:nil];
+    [self.delegate applePayControllerDidCancelTransaction:self];
 }
 
 @end


### PR DESCRIPTION
### Change log:
- Tapping on **Cancel** in the Apple Pay sheet will now trigger a *"User did cancel"* callback event;
- Fix an issue with some of the callback events being executed before the UIViewController dismissed, causing the UIAlerts to not display;