### PR TITLE
[CT-2244] - Crash in `JPCardValidationService`

### DIFF
--- a/JudoKit_iOSTests/Extensions/NSString/NSStringAdditionsTests.swift
+++ b/JudoKit_iOSTests/Extensions/NSString/NSStringAdditionsTests.swift
@@ -127,6 +127,8 @@ class NSStringAdditionsTests: XCTestCase {
     func test_WhenExpiryDateFormatCheck_IfContainsValidFormat_ReturnTrue() {
         XCTAssertTrue("00/00".isExpiryDate)
         XCTAssertTrue("00-00".isExpiryDate)
+        XCTAssertTrue("00/2000".isExpiryDate)
+        XCTAssertTrue("00-2000".isExpiryDate)
         XCTAssertFalse("0/00".isExpiryDate)
         XCTAssertFalse("00/0".isExpiryDate)
         XCTAssertFalse("-00/00".isExpiryDate)
@@ -135,4 +137,20 @@ class NSStringAdditionsTests: XCTestCase {
         XCTAssertFalse("00 - 00".isExpiryDate)
         XCTAssertFalse("00 / 00".isExpiryDate)
     }
+    
+    /*
+     * GIVEN: A string is sanitized and addapted to expected expiry date format
+     *
+     * WHEN: the format is either dd/dd or dd-dd or dd/dddd or dd-dddd, where d is a digit
+     *
+     * THEN: the method should return a date formatted as dd/dd or nil
+     */
+    func test_WhenSanitizedExpiryDate_ReturnExpectedDateFormat() {
+        XCTAssertTrue("00/00".sanitizedExpiryDate() == "00/00")
+        XCTAssertTrue("00-00".sanitizedExpiryDate() == "00/00")
+        XCTAssertTrue("00/2000".sanitizedExpiryDate() == "00/00")
+        XCTAssertTrue("00-2000".sanitizedExpiryDate() == "00/00")
+        XCTAssertTrue("0000-2000".sanitizedExpiryDate() == nil)
+    }
+    
 }

--- a/Source/Extensions/NSString/NSString+Additions.h
+++ b/Source/Extensions/NSString/NSString+Additions.h
@@ -45,6 +45,11 @@
 @property (nonatomic, assign, readonly) BOOL isExpiryDate;
 
 /**
+ * A method which returns a sanitized string that represents a expire date in a valid format
+ */
+- (nullable NSString *)sanitizedExpiryDate;
+
+/**
  * A method which returns YES if the string contains only digits
  */
 @property (nonatomic, assign, readonly) BOOL isNumeric;

--- a/Source/Extensions/NSString/NSString+Additions.m
+++ b/Source/Extensions/NSString/NSString+Additions.m
@@ -109,8 +109,8 @@
      * 12-2022
      * 12/2022
      */
-    NSString *expiryDateFormay = @"^\\d{2}(\\/|-)(\\d{2}|\\d{4})$";
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:expiryDateFormay
+    NSString *expiryDateFormat = @"^\\d{2}(\\/|-)(\\d{2}|\\d{4})$";
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:expiryDateFormat
                                                                            options:NSRegularExpressionAnchorsMatchLines
                                                                              error:nil];
 

--- a/Source/Modules/CardScanController/JPCardScanController.m
+++ b/Source/Modules/CardScanController/JPCardScanController.m
@@ -241,7 +241,7 @@ static const CGFloat kMaxCardErrorMargin = 1.2f;
     NSString *compactText = [detectedText stringByRemovingWhitespaces];
 
     if (compactText.isExpiryDate) {
-        self.detectedExpiryDate = detectedText;
+        self.detectedExpiryDate = [detectedText sanitizedExpiryDate];
     }
 
     JPCardNetworkType cardNetwork = [JPCardNetwork cardNetworkForCardNumber:compactText];


### PR DESCRIPTION
Fixes the issue when scanning a card with a unexpected expire date format generates a crash