### PR TITLE
CT-2721 | iOS SDK: Incorrect country code for St. Lucia

### DIFF
--- a/Source/Resources/JSON/countries-list.json
+++ b/Source/Resources/JSON/countries-list.json
@@ -1107,7 +1107,7 @@
             "alpha2Code": "LC",
             "name": "Saint Lucia",
             "dialCode": "1758",
-            "numericCode": "659"
+            "numericCode": "662"
         },
         {
             "alpha2Code": "MF",


### PR DESCRIPTION
The countries.json has been updated with correct value for St. Lucia.