### PR TITLE
Fix release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,11 @@ workflows:
     when:
       not: << pipeline.parameters.nightly >>
     jobs:
-      - checkout_project
+      - checkout_project:
+          filters:
+            tags:
+              only:
+                - /^v[0-9]+(\.[0-9]+)*$/
       - lint_sdk:
           requires:
             - checkout_project


### PR DESCRIPTION
The `checkout_project` step is a dependency of the `release_sdk` step, but tags will only trigger a step if it's defined in the filter.