### PR TITLE
Refactor form text fields to include appropriate text content type

### DIFF
--- a/Source/View/CardInputView/Subviews/JPBillingInformationForm.m
+++ b/Source/View/CardInputView/Subviews/JPBillingInformationForm.m
@@ -85,6 +85,7 @@ static const float kPhoneCodeWidth = 45.0F;
     self.emailTextField.accessibilityIdentifier = @"Cardholder Email Field";
     self.emailTextField.keyboardType = UIKeyboardTypeEmailAddress;
     self.emailTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    self.emailTextField.textContentType = UITextContentTypeEmailAddress;
 
     self.countryPickerView = [UIPickerView new];
     self.countryPickerView.delegate = self;
@@ -99,11 +100,13 @@ static const float kPhoneCodeWidth = 45.0F;
     self.countryTextField = [JPCardInputField new];
     self.countryTextField.inputView = self.countryPickerView;
     self.countryTextField.accessibilityIdentifier = @"Country Field";
+    self.countryTextField.textContentType = UITextContentTypeCountryName;
 
     self.stateTextField = [JPCardInputField new];
     self.stateTextField.inputView = self.statePickerView;
     self.stateTextField.accessibilityIdentifier = @"State Field";
     self.stateTextField.hidden = YES;
+    self.stateTextField.textContentType = UITextContentTypeAddressState;
 
     self.phoneCodeTextField = [JPPhoneCodeInputField new];
     self.phoneCodeTextField.accessibilityIdentifier = @"Cardholder phone code Field";
@@ -114,11 +117,13 @@ static const float kPhoneCodeWidth = 45.0F;
     self.phoneTextField.accessibilityIdentifier = @"Cardholder phone number Field";
     self.phoneTextField.keyboardType = UIKeyboardTypeNumberPad;
     self.phoneTextField.backgroundMaskedCorners = kCALayerMaxXMinYCorner | kCALayerMaxXMaxYCorner;
+    self.phoneTextField.textContentType = UITextContentTypeTelephoneNumber;
 
     self.line1TextField = [JPCardInputField new];
     self.line1TextField.accessibilityIdentifier = @"Cardholder address line 1 code Field";
     self.line1TextField.keyboardType = UIKeyboardTypeDefault;
     self.line1TextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    self.line1TextField.textContentType = UITextContentTypeStreetAddressLine1;
 
     self.addAddressLineButton = [JPTransactionButton buttonWithType:UIButtonTypeSystem];
     self.addAddressLineButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -133,6 +138,7 @@ static const float kPhoneCodeWidth = 45.0F;
     self.line2TextField.keyboardType = UIKeyboardTypeDefault;
     self.line2TextField.hidden = YES;
     self.line2TextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    self.line2TextField.textContentType = UITextContentTypeStreetAddressLine2;
 
     self.line3TextField = [JPCardInputField new];
     self.line3TextField.accessibilityIdentifier = @"Cardholder address line 3 Field";
@@ -144,10 +150,12 @@ static const float kPhoneCodeWidth = 45.0F;
     self.cityTextField.accessibilityIdentifier = @"Cardholder city Field";
     self.cityTextField.keyboardType = UIKeyboardTypeDefault;
     self.cityTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    self.cityTextField.textContentType = UITextContentTypeAddressCity;
 
     self.postcodeTextField = [JPCardInputField new];
     self.postcodeTextField.keyboardType = UIKeyboardTypeDefault;
     self.postcodeTextField.accessibilityIdentifier = @"Post Code Field";
+    self.postcodeTextField.textContentType = UITextContentTypePostalCode;
 
     UIStackView *phoneNumberStackView = [UIStackView _jp_horizontalStackViewWithSpacing:kSeparatorContentSpacing
                                                                     andArrangedSubviews:@[ self.phoneCodeTextField, self.phoneTextField ]];

--- a/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
+++ b/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
@@ -220,7 +220,7 @@ static const float kInputFieldHeight = 44.0F;
         _cardHolderNameTextField = [JPCardInputField new];
         _cardHolderNameTextField.accessibilityIdentifier = @"Cardholder Name Field";
         _cardHolderNameTextField.keyboardType = UIKeyboardTypeDefault;
-        _cardHolderNameTextField.autocapitalizationType =UITextAutocapitalizationTypeWords;
+        _cardHolderNameTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
         _cardHolderNameTextField.textContentType = UITextContentTypeCreditCardName;
         _cardHolderNameTextField.delegate = self.inputFieldDelegate;
     }

--- a/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
+++ b/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
@@ -209,6 +209,7 @@ static const float kInputFieldHeight = 44.0F;
         _cardNumberTextField = [JPCardNumberField new];
         _cardNumberTextField.accessibilityIdentifier = @"Card Number Field";
         _cardNumberTextField.keyboardType = UIKeyboardTypeNumberPad;
+        _cardNumberTextField.textContentType = UITextContentTypeCreditCardNumber;
         _cardNumberTextField.delegate = self.inputFieldDelegate;
     }
     return _cardNumberTextField;
@@ -219,7 +220,8 @@ static const float kInputFieldHeight = 44.0F;
         _cardHolderNameTextField = [JPCardInputField new];
         _cardHolderNameTextField.accessibilityIdentifier = @"Cardholder Name Field";
         _cardHolderNameTextField.keyboardType = UIKeyboardTypeDefault;
-        [_cardHolderNameTextField setAutocapitalizationType:UITextAutocapitalizationTypeWords];
+        _cardHolderNameTextField.autocapitalizationType =UITextAutocapitalizationTypeWords;
+        _cardHolderNameTextField.textContentType = UITextContentTypeCreditCardName;
         _cardHolderNameTextField.delegate = self.inputFieldDelegate;
     }
     return _cardHolderNameTextField;
@@ -230,6 +232,7 @@ static const float kInputFieldHeight = 44.0F;
         _expiryDateTextField = [JPCardInputField new];
         _expiryDateTextField.accessibilityIdentifier = @"Expiry Date Field";
         _expiryDateTextField.keyboardType = UIKeyboardTypeNumberPad;
+        _expiryDateTextField.textContentType = UITextContentTypeCreditCardExpiration;
         _expiryDateTextField.delegate = self.inputFieldDelegate;
     }
     return _expiryDateTextField;
@@ -240,6 +243,7 @@ static const float kInputFieldHeight = 44.0F;
         _cardSecurityCodeTextField = [JPCardInputField new];
         _cardSecurityCodeTextField.accessibilityIdentifier = @"Security Code Field";
         _cardSecurityCodeTextField.keyboardType = UIKeyboardTypeNumberPad;
+        _cardSecurityCodeTextField.textContentType = UITextContentTypeCreditCardSecurityCode;
         _cardSecurityCodeTextField.delegate = self.inputFieldDelegate;
     }
     return _cardSecurityCodeTextField;
@@ -250,6 +254,7 @@ static const float kInputFieldHeight = 44.0F;
         _countryTextField = [JPCardInputField new];
         _countryTextField.inputView = self.countryPickerView;
         _countryTextField.accessibilityIdentifier = @"Country Field";
+        _countryTextField.textContentType = UITextContentTypeCountryName;
         _countryTextField.delegate = self.inputFieldDelegate;
     }
     return _countryTextField;
@@ -260,6 +265,7 @@ static const float kInputFieldHeight = 44.0F;
         _postcodeTextField = [JPCardInputField new];
         _postcodeTextField.keyboardType = UIKeyboardTypeDefault;
         _postcodeTextField.accessibilityIdentifier = @"Post Code Field";
+        _postcodeTextField.textContentType = UITextContentTypePostalCode;
         _postcodeTextField.delegate = self.inputFieldDelegate;
     }
     return _postcodeTextField;

--- a/Source/View/InputField/JPInputField.h
+++ b/Source/View/InputField/JPInputField.h
@@ -92,6 +92,11 @@ typedef NS_ENUM(NSUInteger, JPInputType);
 @property (nonatomic, assign) UIReturnKeyType returnType;
 
 /**
+ * A property that identify the semantic meaning for the text-entry area
+ */
+@property(nonatomic, strong) UITextContentType textContentType;
+
+/**
  * A reference to the object that adopts the JPInputFieldDelegate protocol
  */
 @property (nonatomic, weak) id<JPInputFieldDelegate> delegate;

--- a/Source/View/InputField/JPInputField.h
+++ b/Source/View/InputField/JPInputField.h
@@ -94,7 +94,7 @@ typedef NS_ENUM(NSUInteger, JPInputType);
 /**
  * A property that identify the semantic meaning for the text-entry area
  */
-@property(nonatomic, strong) UITextContentType textContentType;
+@property (nonatomic, strong) UITextContentType textContentType;
 
 /**
  * A reference to the object that adopts the JPInputFieldDelegate protocol

--- a/Source/View/InputField/JPInputField.m
+++ b/Source/View/InputField/JPInputField.m
@@ -140,6 +140,7 @@ static const float kVerticalEdgeInsets = 14.0F;
 - (void)setKeyboardType:(UIKeyboardType)keyboardType {
     _keyboardType = keyboardType;
     self.floatingTextField.keyboardType = keyboardType;
+    self.floatingTextField.textContentType = UITextContentTypeName;
 }
 
 - (void)setAutocapitalizationType:(UITextAutocapitalizationType)autocapitalizationType {
@@ -150,6 +151,11 @@ static const float kVerticalEdgeInsets = 14.0F;
 - (void)setReturnType:(UIReturnKeyType)returnType {
     _returnType = returnType;
     self.floatingTextField.returnKeyType = returnType;
+}
+
+- (void)setTextContentType:(UITextContentType)textContentType {
+    _textContentType = textContentType;
+    self.floatingTextField.textContentType = textContentType;
 }
 
 - (void)setBackgroundMaskedCorners:(CACornerMask)backgroundMaskedCorners {
@@ -213,6 +219,7 @@ static const float kVerticalEdgeInsets = 14.0F;
         _floatingTextField.translatesAutoresizingMaskIntoConstraints = NO;
         _floatingTextField.font = UIFont._jp_headlineLight;
         _floatingTextField.delegate = self;
+        _floatingTextField.textContentType = _textContentType;
     }
     return _floatingTextField;
 }


### PR DESCRIPTION
The modifications in this commit refactor the form text fields to include the appropriate text content type. The changes include adding the `UITextContentType` property to the relevant text fields and setting it to the appropriate content type such as email address, country name, address state, telephone number, street address line 1 and 2, address city, postal code, credit card number, credit card name, credit card expiration, and credit card security code. This ensures that the keyboard suggestions and autofill functionality work correctly for each text field.