### PR TITLE
Update text content type for certain input fields in card input view

### DIFF
--- a/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
+++ b/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
@@ -221,7 +221,9 @@ static const float kInputFieldHeight = 44.0F;
         _cardHolderNameTextField.accessibilityIdentifier = @"Cardholder Name Field";
         _cardHolderNameTextField.keyboardType = UIKeyboardTypeDefault;
         _cardHolderNameTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
-        _cardHolderNameTextField.textContentType = UITextContentTypeCreditCardName;
+        if (@available(iOS 17.0, *)) {
+            _cardHolderNameTextField.textContentType = UITextContentTypeCreditCardName;
+        }
         _cardHolderNameTextField.delegate = self.inputFieldDelegate;
     }
     return _cardHolderNameTextField;
@@ -232,7 +234,9 @@ static const float kInputFieldHeight = 44.0F;
         _expiryDateTextField = [JPCardInputField new];
         _expiryDateTextField.accessibilityIdentifier = @"Expiry Date Field";
         _expiryDateTextField.keyboardType = UIKeyboardTypeNumberPad;
-        _expiryDateTextField.textContentType = UITextContentTypeCreditCardExpiration;
+        if (@available(iOS 17.0, *)) {
+            _expiryDateTextField.textContentType = UITextContentTypeCreditCardExpiration;
+        }
         _expiryDateTextField.delegate = self.inputFieldDelegate;
     }
     return _expiryDateTextField;
@@ -243,7 +247,9 @@ static const float kInputFieldHeight = 44.0F;
         _cardSecurityCodeTextField = [JPCardInputField new];
         _cardSecurityCodeTextField.accessibilityIdentifier = @"Security Code Field";
         _cardSecurityCodeTextField.keyboardType = UIKeyboardTypeNumberPad;
-        _cardSecurityCodeTextField.textContentType = UITextContentTypeCreditCardSecurityCode;
+        if (@available(iOS 17.0, *)) {
+            _cardSecurityCodeTextField.textContentType = UITextContentTypeCreditCardSecurityCode;
+        }
         _cardSecurityCodeTextField.delegate = self.inputFieldDelegate;
     }
     return _cardSecurityCodeTextField;

--- a/Source/View/InputField/JPInputField.m
+++ b/Source/View/InputField/JPInputField.m
@@ -140,7 +140,6 @@ static const float kVerticalEdgeInsets = 14.0F;
 - (void)setKeyboardType:(UIKeyboardType)keyboardType {
     _keyboardType = keyboardType;
     self.floatingTextField.keyboardType = keyboardType;
-    self.floatingTextField.textContentType = UITextContentTypeName;
 }
 
 - (void)setAutocapitalizationType:(UITextAutocapitalizationType)autocapitalizationType {
@@ -154,8 +153,10 @@ static const float kVerticalEdgeInsets = 14.0F;
 }
 
 - (void)setTextContentType:(UITextContentType)textContentType {
-    _textContentType = textContentType;
-    self.floatingTextField.textContentType = textContentType;
+    if (@available(iOS 10.0, *)) {
+        _textContentType = textContentType;
+        self.floatingTextField.textContentType = textContentType;
+    }
 }
 
 - (void)setBackgroundMaskedCorners:(CACornerMask)backgroundMaskedCorners {
@@ -219,7 +220,9 @@ static const float kVerticalEdgeInsets = 14.0F;
         _floatingTextField.translatesAutoresizingMaskIntoConstraints = NO;
         _floatingTextField.font = UIFont._jp_headlineLight;
         _floatingTextField.delegate = self;
-        _floatingTextField.textContentType = _textContentType;
+        if (@available(iOS 10.0, *)) {
+            _floatingTextField.textContentType = _textContentType;
+        }
     }
     return _floatingTextField;
 }


### PR DESCRIPTION
- Set `UITextContentTypeCreditCardName` for `_cardHolderNameTextField` if available on iOS 17.0 and above
- Set `UITextContentTypeCreditCardExpiration` for `_expiryDateTextField` if available on iOS 17.0 and above
- Set `UITextContentTypeCreditCardSecurityCode` for `_cardSecurityCodeTextField` if available on iOS 17.0 and above

Additionally, update input field text content type in general:
- Set `UITextContentType` for `self.floatingTextField` if available on iOS 10.0 and above