### PR TITLE
CT-2856 | Backward compatibility testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,6 @@ commands:
             }
 
 parameters:
-  nightly:
-    type: boolean
-    default: false
   weekly:
     type: boolean
     default: false
@@ -452,7 +449,7 @@ jobs:
 workflows:  
   build:
     when:
-      not: << pipeline.parameters.nightly >>
+      not: << pipeline.parameters.weekly >>
     jobs:
       - checkout_project:
           filters:
@@ -523,26 +520,10 @@ workflows:
           environment: prod
           requires:
             - release_sdk
-  e2e-nightly:
-    when: << pipeline.parameters.nightly >>
-    jobs:
-      - checkout_project
-      - build_instrumented_tests_package:
-          context: shared-secrets
-      - run_instrumented_tests:      
-          context: shared-secrets
-          requires:
-            - build_instrumented_tests_package
-          filters:
-            branches:
-              only:
-                - master
   e2e-backward-compat-weekly:
       when: << pipeline.parameters.weekly >>
       jobs:
         - checkout_project
-        - build_instrumented_tests_package:
-            context: shared-secrets
         - instrumented_tests_sample_multiple:
             context: shared-secrets
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,7 +524,9 @@ workflows:
       when: << pipeline.parameters.weekly >>
       jobs:
         - checkout_project
-        - build_instrumented_tests_package
+        - build_instrumented_tests_package:
+            requires:
+              - checkout_project
         - instrumented_tests_sample_multiple:
             context: shared-secrets
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,4 +534,4 @@ workflows:
             filters:
               branches:
                 only:
-                  - CT-2856-backward-compat-testing
+                  - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,8 +369,8 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 15.0 \
-              --device version=15.2 \
-              --device version=14.7 \
+              --device model=iphone13pro,version=15.2 \
+              --device model=iphone11pro,version=14.7 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET
       - notify_slack_error_weekly
       - notify_slack_pass_weekly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 15.0 \
-              --device model=iphone14pro \
+              --device model=iphone14pro,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET
       - notify_slack_error
       - notify_slack_pass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,6 +524,7 @@ workflows:
       when: << pipeline.parameters.weekly >>
       jobs:
         - checkout_project
+        - build_instrumented_tests_package
         - instrumented_tests_sample_multiple:
             context: shared-secrets
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,87 @@ commands:
               ]
             }
 
+  notify_slack_pass_weekly:
+    steps:
+      - slack/notify:
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CircleCI has just *successfully* ran the :aapl: iOS E2E mobile tests for backward compatibility, here are the results: \n *<$CIRCLE_BUILD_URL | :circleci: Open build>* \n *<https://console.firebase.google.com/u/0/project/$GOOGLE_PROJECT_ID/testlab/histories/ | :firebase: Firebase results>*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:*\n$CIRCLE_PROJECT_REPONAME"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n$CIRCLE_BRANCH"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:* \n <https://github.com/Judopay/$CIRCLE_PROJECT_REPONAME/commit/${CIRCLE_SHA1} | ${CIRCLE_SHA1:0:7}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author:*\n$CIRCLE_USERNAME"
+                    }
+                  ]
+                }
+              ]
+            }
+
+  notify_slack_error_weekly:
+    steps:
+      - slack/notify:
+          event: fail
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "CircleCI ran the :aapl: iOS E2E mobile tests for backward compatibility but they *failed*, here are the results: \n *<$CIRCLE_BUILD_URL | :circleci: Open build>* \n *<https://console.firebase.google.com/u/0/project/$GOOGLE_PROJECT_ID/testlab/histories/ | :firebase: Firebase results>*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:*\n$CIRCLE_PROJECT_REPONAME"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n$CIRCLE_BRANCH"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:* \n <https://github.com/Judopay/$CIRCLE_PROJECT_REPONAME/commit/${CIRCLE_SHA1} | ${CIRCLE_SHA1:0:7}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author:*\n$CIRCLE_USERNAME"
+                    }
+                  ]
+                }
+              ]
+            }
+
 parameters:
   nightly:
+    type: boolean
+    default: false
+  weekly:
     type: boolean
     default: false
 
@@ -265,9 +344,39 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 15.0 \
+              --device model=iphone14pro \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET
       - notify_slack_error
       - notify_slack_pass
+  instrumented_tests_sample_multiple:
+    executor: macos
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Install Google Cloud CLI
+          command: |
+            brew install google-cloud-sdk --cask
+      - run:
+          name: Store Google Service Account
+          command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+      - run:
+          name: Authorize gcloud and set config defaults
+          command: |
+            gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+      - run:
+          name: Test with Firebase Test Lab
+          no_output_timeout: 30m
+          command: >
+            gcloud firebase test ios run \
+              --test ./Output/ObjectiveCExampleAppUITests.zip \
+              --xcode-version 15.0 \
+              --device version=15.2 \
+              --device version=14.7 \
+              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET
+      - notify_slack_error_weekly
+      - notify_slack_pass_weekly
   run_instrumented_tests:
     executor: macos
     steps:
@@ -421,6 +530,20 @@ workflows:
       - build_instrumented_tests_package:
           context: shared-secrets
       - run_instrumented_tests:      
+          context: shared-secrets
+          requires:
+            - build_instrumented_tests_package
+          filters:
+            branches:
+              only:
+                - master
+e2e-backward-compat-weekly:
+    when: << pipeline.parameters.weekly >>
+    jobs:
+      - checkout_project
+      - build_instrumented_tests_package:
+          context: shared-secrets
+      - instrumented_tests_sample_multiple:
           context: shared-secrets
           requires:
             - build_instrumented_tests_package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -537,17 +537,17 @@ workflows:
             branches:
               only:
                 - master
-e2e-backward-compat-weekly:
-    when: << pipeline.parameters.weekly >>
-    jobs:
-      - checkout_project
-      - build_instrumented_tests_package:
-          context: shared-secrets
-      - instrumented_tests_sample_multiple:
-          context: shared-secrets
-          requires:
-            - build_instrumented_tests_package
-          filters:
-            branches:
-              only:
-                - master
+  e2e-backward-compat-weekly:
+      when: << pipeline.parameters.weekly >>
+      jobs:
+        - checkout_project
+        - build_instrumented_tests_package:
+            context: shared-secrets
+        - instrumented_tests_sample_multiple:
+            context: shared-secrets
+            requires:
+              - build_instrumented_tests_package
+            filters:
+              branches:
+                only:
+                  - CT-2856-backward-compat-testing

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
@@ -304,6 +304,8 @@ final class CardPaymentUITests: XCTestCase {
         
         app.launch()
         
+        app.swipeUp()
+        
         app.cellWithIdentifier(TestData.PREAUTH_METHODS_LABEL)?.tap()
         
         app.addCard?.tap()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,8 @@ platform :ios do
       scheme: "ObjectiveCExampleAppUITests",
       destination: "generic/platform=iOS",
       sdk: "iphoneos",
-      xcodebuild_command: "env NSUnbufferedIO=YES xcodebuild -allowProvisioningUpdates TEST_API_JUDO_ID=$JUDO_API_ID TEST_API_TOKEN=$JUDO_API_TOKEN TEST_API_SECRET=$JUDO_API_SECRET"
+      xcodebuild_command: "env NSUnbufferedIO=YES xcodebuild -allowProvisioningUpdates TEST_API_JUDO_ID=$JUDO_API_ID TEST_API_TOKEN=$JUDO_API_TOKEN TEST_API_SECRET=$JUDO_API_SECRET",
+      include_simulator_logs: false
     }
 
     sync_code_signing sync_code_signing_options


### PR DESCRIPTION
* Configure new job/workflow steps to accommodate testing on previous iOS versions on a weekly basis (every Wed at 12pm UK time)
* Adjust release testing device to iOS 16.6 (was previously 15.7)
* Realised that Firebase does not offer any iOS 17 devices 🤷🏻‍♂️ so put in a request form for this, will see what they say, otherwise look into setting up SauceLabs instead for release testing
* New Slack alerts to differentiate from release testing 🔔 
* PreAuth Payment Methods test was failing so now scrolling to bottom so that feature list item can be tapped without issue
* Add `include_simulator_logs: false` to `fastlane run_tests` config which seems to have fixed the timeout issue we were seeing on CircleCI