### PR TITLE
Updating package version, example app pod dependencies, and making changes to API client.

### DIFF
--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp.xcodeproj/project.pbxproj
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp.xcodeproj/project.pbxproj
@@ -864,7 +864,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 3.3.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.judo.JudoPayDemoObjC;
 				PRODUCT_MODULE_NAME = JudoKit;
@@ -896,7 +896,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 3.3.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.judo.JudoPayDemoObjC;
 				PRODUCT_MODULE_NAME = JudoKit;

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp/AppDelegate.m
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp/AppDelegate.m
@@ -26,7 +26,6 @@
 #import "MainViewController.h"
 #import "Settings.h"
 
-@import CocoaDebug;
 @import JudoKit_iOS;
 
 @implementation AppDelegate
@@ -34,10 +33,6 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Load settings defaults
     [self registerDefaultsFromSettingsBundle];
-
-    // Enable debug inspector
-    [CocoaDebug enable];
-
     return YES;
 }
 

--- a/Examples/ObjectiveCExampleApp/Podfile
+++ b/Examples/ObjectiveCExampleApp/Podfile
@@ -8,11 +8,10 @@ target 'ObjectiveCExampleApp' do
    pod 'Judo3DS2_iOS', '1.1.4'
 
   pod 'JudoKit-iOS', :path => '../../'
-  # pod 'JudoKit-iOS', '3.3.0'
+  # pod 'JudoKit-iOS', '3.3.1'
 
   pod 'MaterialComponents/Snackbar'
   pod 'InAppSettingsKit', '3.3.6'
-  pod 'CocoaDebug', '1.7.2'
   
   target 'ObjectiveCExampleAppTests' do
     inherit! :search_paths

--- a/Examples/ObjectiveCExampleApp/Podfile.lock
+++ b/Examples/ObjectiveCExampleApp/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - CocoaDebug (1.7.2)
   - DeviceDNA (2.0.0):
     - OpenSSL-Universal (~> 1.1.180)
   - InAppSettingsKit (3.3.6)
@@ -83,7 +82,6 @@ PODS:
   - TrustKit (3.0.3)
 
 DEPENDENCIES:
-  - CocoaDebug (= 1.7.2)
   - InAppSettingsKit (= 3.3.6)
   - Judo3DS2_iOS (= 1.1.4)
   - JudoKit-iOS (from `../../`)
@@ -91,7 +89,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - CocoaDebug
     - DeviceDNA
     - InAppSettingsKit
     - Judo3DS2_iOS
@@ -107,7 +104,6 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  CocoaDebug: 61cf93ada6ce8f3407507dc01f9b874d91ac1d5c
   DeviceDNA: 9ff289d1fb983937754b324fa0adade2081210c4
   InAppSettingsKit: 37df0b44132380d4c7db6fc7cded92997e29873a
   Judo3DS2_iOS: 5cca966ec8425a315d6a96ff64f0b760dd991f32
@@ -119,6 +115,6 @@ SPEC CHECKSUMS:
   RavelinEncrypt: 343327b88f39802bc269ae00da831a801982388b
   TrustKit: 7858ea59d0e226b1457b2e9cc8b95d77ab21d471
 
-PODFILE CHECKSUM: d0586020c8fd66f32b8a19cf1accd70d59bffb6d
+PODFILE CHECKSUM: 764b102bb209c4df2d2bf24e192fc0ba1aa85283
 
 COCOAPODS: 1.14.3

--- a/JudoKit-iOS.podspec
+++ b/JudoKit-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'JudoKit-iOS'
-  s.version               = '3.3.0'
+  s.version               = '3.3.1'
   s.summary               = 'Judo Pay Full iOS Client Kit'
   s.homepage              = 'https://www.judopay.com/'
   s.license               = 'MIT'

--- a/Source/Models/Constants/JPConstants.h
+++ b/Source/Models/Constants/JPConstants.h
@@ -28,7 +28,7 @@
 #import <Foundation/Foundation.h>
 
 static NSString *const kJudoKitName = @"JudoKit_iOS";
-static NSString *const kJudoKitVersion = @"3.3.0";
+static NSString *const kJudoKitVersion = @"3.3.1";
 
 /* Patterns */
 static NSString *const kDefaultPattern = @"XXXX XXXX XXXX XXXX";


### PR DESCRIPTION
Description:
- Update JudoKit-iOS version from 3.3.0 to 3.3.1.
- Update JPSession's trustKit and urlSession properties to be lazily loaded and a bit of general cleanup.
- Remove the CocoaDebug pod dependency, as it's causing random issues with NSURLSession swizzled methods.