### PR TITLE
chore: replacing Cocoadebug with Wormholy as the first looks to be stagnant and causes network timeouts.

### DIFF
--- a/Examples/ObjectiveCExampleApp/Podfile
+++ b/Examples/ObjectiveCExampleApp/Podfile
@@ -12,6 +12,7 @@ target 'ObjectiveCExampleApp' do
 
   pod 'MaterialComponents/Snackbar'
   pod 'InAppSettingsKit', '3.3.6'
+  pod 'Wormholy'
   
   target 'ObjectiveCExampleAppTests' do
     inherit! :search_paths

--- a/Examples/ObjectiveCExampleApp/Podfile.lock
+++ b/Examples/ObjectiveCExampleApp/Podfile.lock
@@ -80,12 +80,14 @@ PODS:
   - OpenSSL-Universal (1.1.2200)
   - RavelinEncrypt (1.1.1)
   - TrustKit (3.0.3)
+  - Wormholy (1.7.0)
 
 DEPENDENCIES:
   - InAppSettingsKit (= 3.3.6)
   - Judo3DS2_iOS (= 1.1.4)
   - JudoKit-iOS (from `../../`)
   - MaterialComponents/Snackbar
+  - Wormholy
 
 SPEC REPOS:
   trunk:
@@ -98,6 +100,7 @@ SPEC REPOS:
     - OpenSSL-Universal
     - RavelinEncrypt
     - TrustKit
+    - Wormholy
 
 EXTERNAL SOURCES:
   JudoKit-iOS:
@@ -114,7 +117,8 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: 6e1ae0555546e604dbc632a2b9a24a9c46c41ef6
   RavelinEncrypt: 343327b88f39802bc269ae00da831a801982388b
   TrustKit: 7858ea59d0e226b1457b2e9cc8b95d77ab21d471
+  Wormholy: ab1c8c2f02f58587a0941deb0088555ffbf039a1
 
-PODFILE CHECKSUM: 09c1a52cd4f8353d234b3c5a8ac9eb494080f62e
+PODFILE CHECKSUM: f7f106f149ef4b85cef44b1b2579fb7fd438afe6
 
 COCOAPODS: 1.14.3

--- a/Examples/SwiftExampleApp/Podfile
+++ b/Examples/SwiftExampleApp/Podfile
@@ -9,7 +9,7 @@ target 'SwiftExampleApp' do
   pod 'JudoKit-iOS', :path => '../../'
 
   pod 'InAppSettingsKit', '3.3.6'
-  pod 'CocoaDebug', '1.7.7'
+  pod 'Wormholy'
   pod 'SwiftLint'
 
   target 'SwiftExampleAppTests' do

--- a/Examples/SwiftExampleApp/Podfile.lock
+++ b/Examples/SwiftExampleApp/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - CocoaDebug (1.7.7)
   - DeviceDNA (2.0.0):
     - OpenSSL-Universal (~> 1.1.180)
   - InAppSettingsKit (3.3.6)
@@ -13,17 +12,17 @@ PODS:
   - RavelinEncrypt (1.1.1)
   - SwiftLint (0.51.0)
   - TrustKit (3.0.2)
+  - Wormholy (1.7.0)
 
 DEPENDENCIES:
-  - CocoaDebug (= 1.7.7)
   - InAppSettingsKit (= 3.3.6)
   - Judo3DS2_iOS (= 1.1.4)
   - JudoKit-iOS (from `../../`)
   - SwiftLint
+  - Wormholy
 
 SPEC REPOS:
   trunk:
-    - CocoaDebug
     - DeviceDNA
     - InAppSettingsKit
     - Judo3DS2_iOS
@@ -31,13 +30,13 @@ SPEC REPOS:
     - RavelinEncrypt
     - SwiftLint
     - TrustKit
+    - Wormholy
 
 EXTERNAL SOURCES:
   JudoKit-iOS:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  CocoaDebug: b38d31464b91a9775928f8667d114db07b136565
   DeviceDNA: 9ff289d1fb983937754b324fa0adade2081210c4
   InAppSettingsKit: 37df0b44132380d4c7db6fc7cded92997e29873a
   Judo3DS2_iOS: 5cca966ec8425a315d6a96ff64f0b760dd991f32
@@ -46,7 +45,8 @@ SPEC CHECKSUMS:
   RavelinEncrypt: 343327b88f39802bc269ae00da831a801982388b
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
   TrustKit: 55804401e9a95db0bbfff9a08373bfd91953071f
+  Wormholy: ab1c8c2f02f58587a0941deb0088555ffbf039a1
 
-PODFILE CHECKSUM: 9b36b37c6f700efc47722cb28a3f5d21ee9443bf
+PODFILE CHECKSUM: 32d9b4b90badb6f4646a7739bd4dde07ab5c11aa
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
Replacing Cocoadebug with Wormholy as the first looks to be stagnant and causes network timeouts.
(to trigger Wormholy HTTP requests logger screen - shake your phone)