### PR TITLE
Unifies No-UI payments screen with Android and ObjectiveC

### DIFF
--- a/Examples/SwiftExampleApp/SwiftExampleApp/Modules/Home/Services/FeatureService.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleApp/Modules/Home/Services/FeatureService.swift
@@ -48,6 +48,10 @@ class FeatureService {
         transactionService.invokePreAuthPayment(with: details, andCompletion: completion)
     }
 
+    func invokeCheckCard(withDetails details: JPCardTransactionDetails, completion: @escaping JPCompletionBlock) {
+        transactionService.invokeCheckCard(with: details, andCompletion: completion)
+    }
+
     func getTransactionDetails(with receiptID: String,
                                and completion: @escaping JPCompletionBlock) {
         apiService.fetchTransaction(withReceiptId: receiptID, completion: completion)

--- a/Examples/SwiftExampleApp/SwiftExampleApp/Modules/NoUICardPay/NoUICardPayView.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleApp/Modules/NoUICardPay/NoUICardPayView.swift
@@ -3,16 +3,22 @@ import SwiftUI
 struct NoUICardPayView: View {
     @StateObject var viewModel: NoUICardPayViewModel
     var coordinator: Coordinator?
-
     var body: some View {
-        VStack(spacing: 32) {
+        VStack(spacing: 10) {
             Button("Pay with card") {
-                viewModel.payWithCardToken()
+                viewModel.payWithCard()
             }
-            Button("Pre-auth with card") {
-                viewModel.preAuthWithCardToken()
+            .buttonStyle(BasicButtonStyle())
+            Button("PreAuth with card") {
+                viewModel.preAuthWithCard()
             }
+            .buttonStyle(BasicButtonStyle())
+            Button("Check card") {
+                viewModel.checkCard()
+            }
+            .buttonStyle(BasicButtonStyle())
         }
+        .padding()
         .navigationBarTitle("No UI payments")
         .alert(isPresented: $viewModel.showAlert) {
             Alert(
@@ -27,6 +33,18 @@ struct NoUICardPayView: View {
                 coordinator?.pushTo(.results(result))
             }
         }
+    }
+}
+
+struct BasicButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .frame(maxWidth: .infinity)
+            .background(Color.black)
+            .foregroundColor(.white)
+            .cornerRadius(4)
+            .scaleEffect(configuration.isPressed ? 0.99 : 1.0)
     }
 }
 

--- a/Examples/SwiftExampleApp/SwiftExampleApp/Modules/NoUICardPay/NoUICardPayViewModel.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleApp/Modules/NoUICardPay/NoUICardPayViewModel.swift
@@ -11,12 +11,16 @@ class NoUICardPayViewModel: ObservableObject {
         self.featureService = featureService
     }
 
-    func payWithCardToken() {
+    func payWithCard() {
         featureService.invokePayment(withDetails: cardTransactionDetails, completion: completion)
     }
 
-    func preAuthWithCardToken() {
+    func preAuthWithCard() {
         featureService.invokePreAuthPayment(withDetails: cardTransactionDetails, completion: completion)
+    }
+
+    func checkCard() {
+        featureService.invokeCheckCard(withDetails: cardTransactionDetails, completion: completion)
     }
 
     private var cardTransactionDetails: JPCardTransactionDetails {


### PR DESCRIPTION
Before & After
#tested (by me, Eugene not yet)

<img width="887" alt="Screenshot 2024-09-17 at 15 18 48" src="https://github.com/user-attachments/assets/d8b49371-6a17-4aee-a45a-0b4655249fd5">
