### PR TITLE
Improves strings (missed typo)

### DIFF
--- a/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
+++ b/Source/Modules/Transaction/Presenter/JPTransactionPresenter.m
@@ -129,12 +129,12 @@
 
     billingInformationViewModel.phoneCodeViewModel.text = currentSelectedCountry.dialCode;
     billingInformationViewModel.phoneViewModel.placeholder = @"jp_card_holder_phone_hint"._jp_localized;
-    billingInformationViewModel.addressLine1ViewModel.placeholder = [NSString stringWithFormat:@"jp_card_holder_adress_line_hint"._jp_localized, @(1)];
+    billingInformationViewModel.addressLine1ViewModel.placeholder = [NSString stringWithFormat:@"jp_card_holder_address_line_hint"._jp_localized, @(1)];
 
-    billingInformationViewModel.addressLine2ViewModel.placeholder = [NSString stringWithFormat:@"jp_card_holder_adress_line_hint"._jp_localized, @(2)];
+    billingInformationViewModel.addressLine2ViewModel.placeholder = [NSString stringWithFormat:@"jp_card_holder_address_line_hint"._jp_localized, @(2)];
     billingInformationViewModel.addressLine2ViewModel.isValid = YES;
 
-    billingInformationViewModel.addressLine3ViewModel.placeholder = [NSString stringWithFormat:@"jp_card_holder_adress_line_hint"._jp_localized, @(3)];
+    billingInformationViewModel.addressLine3ViewModel.placeholder = [NSString stringWithFormat:@"jp_card_holder_address_line_hint"._jp_localized, @(3)];
     billingInformationViewModel.addressLine3ViewModel.isValid = YES;
 
     billingInformationViewModel.cityViewModel.placeholder = @"jp_card_holder_city_hint"._jp_localized;

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -37,7 +37,7 @@
 "jp_card_holder_province_hint" = "Province or territory";
 "jp_card_holder_phone_hint" = "Mobile number";
 "jp_card_holder_city_hint" = "City";
-"jp_card_holder_adress_line_hint" = "Address line %@";
+"jp_card_holder_address_line_hint" = "Address line %@";
 "jp_card_number_hint" = "Card Number";
 "jp_card_subtitle" = "%@ Ending";
 "jp_cards" = "Cards";

--- a/Source/Resources/es.lproj/Localizable.strings
+++ b/Source/Resources/es.lproj/Localizable.strings
@@ -37,7 +37,7 @@
 "jp_card_holder_province_hint" = "Provincia o territorio";
 "jp_card_holder_phone_hint" = "Mobile number";
 "jp_card_holder_city_hint" = "City";
-"jp_card_holder_adress_line_hint" = "Address line %@";
+"jp_card_holder_address_line_hint" = "Address line %@";
 "jp_card_number_hint" = "Numero de tarjeta";
 "jp_card_subtitle" = "%@ Terminación";
 "jp_cards" = "Tarjetas ";

--- a/Source/Resources/fr.lproj/Localizable.strings
+++ b/Source/Resources/fr.lproj/Localizable.strings
@@ -36,7 +36,7 @@
 "jp_card_holder_province_hint" = "Province ou territoire";
 "jp_card_holder_phone_hint" = "Mobile number";
 "jp_card_holder_city_hint" = "City";
-"jp_card_holder_adress_line_hint" = "Address line %@";
+"jp_card_holder_address_line_hint" = "Address line %@";
 "jp_card_holder_email_hint" = "Email";
 "jp_card_number_hint" = "Numéro de carte";
 "jp_card_subtitle" = "%@ Se Terminant";


### PR DESCRIPTION
Fixes typo spotted by Alison. It's better to fix it now, so it looks good in documentation.