### PR TITLE
Reduce test flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ jobs:
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --timeout=30m \
-              --num-flaky-test-attempts=2 \
+              --num-flaky-test-attempts=1 \
       # - notify_slack_error
       # - notify_slack_pass
   instrumented_tests_sample_ipad:
@@ -428,7 +428,7 @@ jobs:
                   --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
                   --client-details=matrixLabel="Regression E2E (iPad)" \
                   --timeout=30m \
-                  --num-flaky-test-attempts=2 \
+                  --num-flaky-test-attempts=1 \
           # - notify_slack_error
           # - notify_slack_pass
   instrumented_tests_sample_multiple:
@@ -455,7 +455,7 @@ jobs:
               --device model=iphone8,version=15.7 \
               --device model=iphone12pro,version=14.8 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
-              --num-flaky-test-attempts=2 \
+              --num-flaky-test-attempts=1 \
               --client-details=matrixLabel="Backward Compat E2E" \
               --timeout=30m \
       - notify_slack_error_weekly
@@ -484,7 +484,7 @@ jobs:
               --device model=iphone14pro,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
-              --num-flaky-test-attempts=2 \
+              --num-flaky-test-attempts=1 \
               --timeout=30m \
       # - notify_slack_error
       # - notify_slack_pass
@@ -512,7 +512,7 @@ jobs:
                   --device model=ipad10,version=16.6 \
                   --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
                   --client-details=matrixLabel="Regression E2E (iPad)" \
-                  --num-flaky-test-attempts=2 \
+                  --num-flaky-test-attempts=1 \
                   --timeout=30m \
           # - notify_slack_error
           # - notify_slack_pass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,9 +398,10 @@ jobs:
               --xcode-version 15.3 \
               --device model=iphone14pro,version=16.6 \
               --device model=ipad10,version=16.6 \
-              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET
-      - notify_slack_error
-      - notify_slack_pass
+              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
+              --client-details=matrixLabel="Regression E2E" \
+      # - notify_slack_error
+      # - notify_slack_pass
   instrumented_tests_sample_multiple:
     executor: macos
     steps:
@@ -425,7 +426,8 @@ jobs:
               --device model=iphone8,version=15.7 \
               --device model=iphone12pro,version=14.8 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
-              --num-flaky-test-attempts=2
+              --num-flaky-test-attempts=2 \
+              --client-details=matrixLabel="Backward Compat E2E"
       - notify_slack_error_weekly
       - notify_slack_pass_weekly
   instrumented_tests_swift_sample:
@@ -451,9 +453,10 @@ jobs:
               --xcode-version 15.3 \
               --device model=iphone14pro,version=16.6 \
               --device model=ipad10,version=16.6 \
-              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET
-      - notify_slack_error
-      - notify_slack_pass
+              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
+              --client-details=matrixLabel="Regression E2E" \
+      # - notify_slack_error
+      # - notify_slack_pass
   release_sample:
     executor: macos
     steps:
@@ -530,7 +533,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - reduce-test-flakiness
       - build_instrumented_tests_swift_package:
           requires:
             - unit_test_sdk
@@ -541,7 +544,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - reduce-test-flakiness
       - release_sample:
           context: shared-secrets
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,8 @@ jobs:
               --device model=iphone12pro,version=14.8 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --num-flaky-test-attempts=2 \
-              --client-details=matrixLabel="Backward Compat E2E"
+              --client-details=matrixLabel="Backward Compat E2E" \
+              --timeout=30m \
       - notify_slack_error_weekly
       - notify_slack_pass_weekly
   instrumented_tests_swift_sample:
@@ -455,6 +456,8 @@ jobs:
               --device model=ipad10,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E" \
+              --num-flaky-test-attempts=2 \
+              --timeout=30m \
       # - notify_slack_error
       # - notify_slack_pass
   release_sample:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,8 +401,8 @@ jobs:
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --timeout=30m \
               --num-flaky-test-attempts=1 \
-      # - notify_slack_error
-      # - notify_slack_pass
+      - notify_slack_error
+      - notify_slack_pass
   instrumented_tests_sample_ipad:
         executor: macos
         steps:
@@ -428,9 +428,7 @@ jobs:
                   --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
                   --client-details=matrixLabel="Regression E2E (iPad)" \
                   --timeout=30m \
-                  --num-flaky-test-attempts=1 \
-          # - notify_slack_error
-          # - notify_slack_pass
+                  --num-flaky-test-attempts=1
   instrumented_tests_sample_multiple:
     executor: macos
     steps:
@@ -457,7 +455,7 @@ jobs:
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --num-flaky-test-attempts=1 \
               --client-details=matrixLabel="Backward Compat E2E" \
-              --timeout=30m \
+              --timeout=30m
       - notify_slack_error_weekly
       - notify_slack_pass_weekly
   instrumented_tests_swift_sample_iphone:
@@ -485,9 +483,9 @@ jobs:
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --num-flaky-test-attempts=1 \
-              --timeout=30m \
-      # - notify_slack_error
-      # - notify_slack_pass
+              --timeout=30m
+      - notify_slack_error
+      - notify_slack_pass
   instrumented_tests_swift_sample_ipad:
         executor: macos
         steps:
@@ -513,9 +511,7 @@ jobs:
                   --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
                   --client-details=matrixLabel="Regression E2E (iPad)" \
                   --num-flaky-test-attempts=1 \
-                  --timeout=30m \
-          # - notify_slack_error
-          # - notify_slack_pass
+                  --timeout=30m
   release_sample:
     executor: macos
     steps:
@@ -592,7 +588,7 @@ workflows:
           filters:
             branches:
               only:
-                - reduce-test-flakiness
+                - master
       - instrumented_tests_sample_ipad:
           context: shared-secrets
           requires:
@@ -600,7 +596,7 @@ workflows:
           filters:
             branches:
               only:
-                - reduce-test-flakiness
+                - master
       - build_instrumented_tests_swift_package:
           requires:
             - unit_test_sdk
@@ -611,7 +607,7 @@ workflows:
           filters:
             branches:
               only:
-                - reduce-test-flakiness
+                - master
       - instrumented_tests_swift_sample_ipad:
           context: shared-secrets
           requires:
@@ -619,7 +615,7 @@ workflows:
           filters:
             branches:
               only:
-                - reduce-test-flakiness
+                - master
       - release_sample:
           context: shared-secrets
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
           path: ./Output/BuildLogs/
           destination: BuildLogs
 
-  instrumented_tests_sample:
+  instrumented_tests_sample_iphone:
     executor: macos
     steps:
       - attach_workspace:
@@ -397,11 +397,40 @@ jobs:
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 15.3 \
               --device model=iphone14pro,version=16.6 \
-              --device model=ipad10,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
-              --client-details=matrixLabel="Regression E2E" \
+              --client-details=matrixLabel="Regression E2E (iPhone)" \
+              --timeout=30m \
+              --num-flaky-test-attempts=2 \
       # - notify_slack_error
       # - notify_slack_pass
+  instrumented_tests_sample_ipad:
+        executor: macos
+        steps:
+          - attach_workspace:
+              at: ~/project
+          - brew_install
+          - run:
+              name: Store Google Service Account
+              command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+          - run:
+              name: Authorize gcloud and set config defaults
+              command: |
+                gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+                gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+          - run:
+              name: Test with Firebase Test Lab
+              no_output_timeout: 30m
+              command: >
+                gcloud firebase test ios run \
+                  --test ./Output/ObjectiveCExampleAppUITests.zip \
+                  --xcode-version 15.3 \
+                  --device model=ipad10,version=16.6 \
+                  --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
+                  --client-details=matrixLabel="Regression E2E (iPad)" \
+                  --timeout=30m \
+                  --num-flaky-test-attempts=2 \
+          # - notify_slack_error
+          # - notify_slack_pass
   instrumented_tests_sample_multiple:
     executor: macos
     steps:
@@ -431,7 +460,7 @@ jobs:
               --timeout=30m \
       - notify_slack_error_weekly
       - notify_slack_pass_weekly
-  instrumented_tests_swift_sample:
+  instrumented_tests_swift_sample_iphone:
     executor: macos
     steps:
       - attach_workspace:
@@ -453,13 +482,40 @@ jobs:
               --test ./Output/SwiftExampleAppUITests.zip \
               --xcode-version 15.3 \
               --device model=iphone14pro,version=16.6 \
-              --device model=ipad10,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
-              --client-details=matrixLabel="Regression E2E" \
+              --client-details=matrixLabel="Regression E2E (iPhone)" \
               --num-flaky-test-attempts=2 \
               --timeout=30m \
       # - notify_slack_error
       # - notify_slack_pass
+  instrumented_tests_swift_sample_ipad:
+        executor: macos
+        steps:
+          - attach_workspace:
+              at: ~/project
+          - brew_install
+          - run:
+              name: Store Google Service Account
+              command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+          - run:
+              name: Authorize gcloud and set config defaults
+              command: |
+                gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+                gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+          - run:
+              name: Test with Firebase Test Lab
+              no_output_timeout: 30m
+              command: >
+                gcloud firebase test ios run \
+                  --test ./Output/SwiftExampleAppUITests.zip \
+                  --xcode-version 15.3 \
+                  --device model=ipad10,version=16.6 \
+                  --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
+                  --client-details=matrixLabel="Regression E2E (iPad)" \
+                  --num-flaky-test-attempts=2 \
+                  --timeout=30m \
+          # - notify_slack_error
+          # - notify_slack_pass
   release_sample:
     executor: macos
     steps:
@@ -529,7 +585,15 @@ workflows:
       - build_instrumented_tests_package:
           requires:
             - unit_test_sdk
-      - instrumented_tests_sample:
+      - instrumented_tests_sample_iphone:
+          context: shared-secrets
+          requires:
+            - build_instrumented_tests_package
+          filters:
+            branches:
+              only:
+                - reduce-test-flakiness
+      - instrumented_tests_sample_ipad:
           context: shared-secrets
           requires:
             - build_instrumented_tests_package
@@ -540,7 +604,15 @@ workflows:
       - build_instrumented_tests_swift_package:
           requires:
             - unit_test_sdk
-      - instrumented_tests_swift_sample:
+      - instrumented_tests_swift_sample_iphone:
+          context: shared-secrets
+          requires:
+            - build_instrumented_tests_swift_package
+          filters:
+            branches:
+              only:
+                - reduce-test-flakiness
+      - instrumented_tests_swift_sample_ipad:
           context: shared-secrets
           requires:
             - build_instrumented_tests_swift_package

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp.xcodeproj/xcshareddata/xcschemes/ObjectiveCExampleAppUITests.xcscheme
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp.xcodeproj/xcshareddata/xcschemes/ObjectiveCExampleAppUITests.xcscheme
@@ -92,9 +92,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "IdealUITests">
-               </Test>
-               <Test
                   Identifier = "RavelinUITests/testCheckCardAllowAuthenticateLowValueNoPreference()">
                </Test>
                <Test

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp.xcodeproj/xcshareddata/xcschemes/ObjectiveCExampleAppUITests.xcscheme
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp.xcodeproj/xcshareddata/xcschemes/ObjectiveCExampleAppUITests.xcscheme
@@ -92,6 +92,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "IdealUITests">
+               </Test>
+               <Test
                   Identifier = "RavelinUITests/testCheckCardAllowAuthenticateLowValueNoPreference()">
                </Test>
                <Test

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
@@ -76,9 +76,7 @@ func tapCompleteButton(_ app: XCUIApplication) {
     
     sleep(10)
     
-    if completeButton.isHittable {
-        completeButton.tap()
-    }
+    completeButton.tap()
 }
 
 func assertResultObjectNotDisplayed(_ app: XCUIApplication) {
@@ -160,10 +158,8 @@ func assertNoRequestToJudoAPI(_ app: XCUIApplication) {
 }
 
 func toggleHaltTransactionSwitchIfOff(_ app: XCUIApplication) {
-    if let value = app.haltTransactionSwitchValue {
-        if value == "0" {
-            app.haltTransactionSwitch?.tap()
-        }
+    if app.haltTransactionSwitchValue == "0" {
+        app.haltTransactionSwitch?.tap()
     } else {
         print("Switch not found")
     }

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
@@ -158,3 +158,13 @@ func assertNoRequestToJudoAPI(_ app: XCUIApplication) {
     }
     XCTAssertFalse(paymentRequestLabel.exists)
 }
+
+func toggleHaltTransactionSwitchIfOff(_ app: XCUIApplication) {
+    if let value = app.haltTransactionSwitchValue {
+        if value == "0" {
+            app.haltTransactionSwitch?.tap()
+        }
+    } else {
+        print("Switch not found")
+    }
+}

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
@@ -74,17 +74,10 @@ func tapCompleteButton(_ app: XCUIApplication) {
     let completeButton = app.buttons["COMPLETE"]
     XCTAssert(completeButton.waitForExistence(timeout: 30))
     
-    var retryCount = 0
+    sleep(10)
     
-    // Due to GlobalPay environment, sometimes the page does not proceed with a single tap of the Complete button
-    while completeButton.exists && retryCount < 5 {
-        if completeButton.isHittable {
-            completeButton.tap()
-        } else {
-            print("Complete button is not tappable.")
-            sleep(3)
-        }
-        retryCount += 1
+    if completeButton.isHittable {
+        completeButton.tap()
     }
 }
 

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Selectors.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Selectors.swift
@@ -63,6 +63,7 @@ class Selectors {
         static let padSearchTerm = "primaryaccountdetails"
         static let haltTransactionSwitch = "Halt transaction in case of any error"
         static let backButton = "Judopay examples"
+        static let cancelledPaymentToastLabel = "messageLabel"
     }
     struct Ideal {
         static let makePaymentButton = "Make Payment"

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/TestData.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/TestData.swift
@@ -47,7 +47,7 @@ class TestData {
         static let INVALID_CITY_LABEL = "Please enter a valid city"
     }
     struct Other {
-        static let CANCELLED_PAYMENT_TOAST = "The transaction was cancelled by the user."
+        static let CANCELLED_PAYMENT_TOAST = "messageLabel"
         static let CANCELLED_3DS2_PAYMENT_TOAST = "Unable to process transaction. Card authentication failed with 3DS Server."
         static let IDEAL_CANCELLED_PAYMENT_ALERT = "Card transaction unsuccessful - please try again"
     }

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/TestData.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/TestData.swift
@@ -47,7 +47,6 @@ class TestData {
         static let INVALID_CITY_LABEL = "Please enter a valid city"
     }
     struct Other {
-        static let CANCELLED_PAYMENT_TOAST = "messageLabel"
         static let CANCELLED_3DS2_PAYMENT_TOAST = "Unable to process transaction. Card authentication failed with 3DS Server."
         static let IDEAL_CANCELLED_PAYMENT_ALERT = "Card transaction unsuccessful - please try again"
     }

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/XCUIApplication+Additions.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/XCUIApplication+Additions.swift
@@ -224,12 +224,7 @@ extension XCUIApplication {
     }
     
     var haltTransactionSwitchValue: String? {
-        get {
-            guard let haltSwitch = switchWithLabel(Selectors.Other.haltTransactionSwitch) else {
-                return nil
-            }
-            return haltSwitch.value as? String
-        }
+        (switchWithLabel(Selectors.Other.haltTransactionSwitch)?.value as? String)
     }
     
     var backButton: XCUIElement? {

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/XCUIApplication+Additions.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/XCUIApplication+Additions.swift
@@ -223,6 +223,15 @@ extension XCUIApplication {
         }
     }
     
+    var haltTransactionSwitchValue: String? {
+        get {
+            guard let haltSwitch = switchWithLabel(Selectors.Other.haltTransactionSwitch) else {
+                return nil
+            }
+            return haltSwitch.value as? String
+        }
+    }
+    
     var backButton: XCUIElement? {
         get {
             return buttonWithLabel(Selectors.Other.backButton)

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
@@ -36,7 +36,8 @@ final class CardPaymentUITests: XCTestCase {
         app.launch()
         app.cellWithIdentifier(Selectors.FeatureList.payWithCard)?.tap()
         app.cancelButton?.tap()
-        let snackbar = app.buttonWithLabel(TestData.Other.CANCELLED_PAYMENT_TOAST)
+        sleep(1)
+        let snackbar = app.textWithIdentifier(TestData.Other.CANCELLED_PAYMENT_TOAST)
         XCTAssert(snackbar!.exists, "Snackbar message not displayed")
     }
     
@@ -61,7 +62,7 @@ final class CardPaymentUITests: XCTestCase {
                              securityCode: "123")
         app.cardDetailsSubmitButton?.tap()
         tapCompleteButton(app)
-        assertResultObject(app, "Payment", "Card declined: Additional customer authentication required", "Declined")
+        assertResultObject(app, "Payment", "Card declined: CV2 policy", "Declined")
     }
 
     func testFailedTransaction() {

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
@@ -37,7 +37,7 @@ final class CardPaymentUITests: XCTestCase {
         app.cellWithIdentifier(Selectors.FeatureList.payWithCard)?.tap()
         app.cancelButton?.tap()
         sleep(1)
-        let snackbar = app.textWithIdentifier(TestData.Other.CANCELLED_PAYMENT_TOAST)
+        let snackbar = app.textWithIdentifier(Selectors.Other.cancelledPaymentToastLabel)
         XCTAssert(snackbar!.exists, "Snackbar message not displayed")
     }
     

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
@@ -62,7 +62,7 @@ final class CardPaymentUITests: XCTestCase {
                              securityCode: "123")
         app.cardDetailsSubmitButton?.tap()
         tapCompleteButton(app)
-        assertResultObject(app, "Payment", "Card declined: CV2 policy", "Declined")
+        assertResultObject(app, "Payment", "Card declined: Additional customer authentication required", "Declined")
     }
 
     func testFailedTransaction() {

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Ravelin/RavelinUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Ravelin/RavelinUITests.swift
@@ -153,7 +153,7 @@ final class RavelinUITests: XCTestCase {
         app.configureRavelin(suffix: "5")
         app.ravelinTestSetup()
         app.settingsButton?.tap()
-        app.haltTransactionSwitch?.tap()
+        toggleHaltTransactionSwitchIfOff(app)
         app.backButton?.tap()
         app.cellWithIdentifier(Selectors.FeatureList.payWithCard)?.tap()
         app.fillCardSheetDetails(cardNumber: TestData.CardDetails.CARD_NUMBER,
@@ -161,6 +161,7 @@ final class RavelinUITests: XCTestCase {
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
         app.cardDetailsSubmitButton?.tap()
+        sleep(3)
         assertNoRequestToJudoAPI(app)
     }
 }

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/CardPayment/CardPaymentUITests.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/CardPayment/CardPaymentUITests.swift
@@ -302,6 +302,7 @@ final class CardPaymentUITests: XCTestCase {
                                    city: Constants.BillingInfo.validCity,
                                    postCode: Constants.BillingInfo.invalidPostcode)
         app.cityField?.tap()
+        sleep(1)
         XCTAssertEqual(app.fieldErrorLabel, Constants.BillingInfo.invalidPostcodeLabel)
         XCTAssertFalse(app.cardDetailsSubmitButton!.isEnabled)
     }

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/Helpers.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/Helpers.swift
@@ -58,17 +58,10 @@ func tapCompleteButton(_ app: XCUIApplication) {
     let completeButton = app.buttons["COMPLETE"]
     XCTAssert(completeButton.waitForExistence(timeout: 30))
 
-    var retryCount = 0
-
-    // Due to GlobalPay environment, sometimes the page does not proceed with a single tap of the Complete button
-    while completeButton.exists && retryCount < 5 {
-        if completeButton.isHittable {
-            completeButton.tap()
-        } else {
-            print("Complete button is not tappable.")
-            sleep(3)
-        }
-        retryCount += 1
+    sleep(10)
+    
+    if completeButton.isHittable {
+        completeButton.tap()
     }
 }
 

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/Helpers.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/Helpers.swift
@@ -60,9 +60,7 @@ func tapCompleteButton(_ app: XCUIApplication) {
 
     sleep(10)
     
-    if completeButton.isHittable {
-        completeButton.tap()
-    }
+    completeButton.tap()
 }
 
 func assertResultObjectNotDisplayed(_ app: XCUIApplication) {

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/Ideal/IdealUITests.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/Ideal/IdealUITests.swift
@@ -22,11 +22,11 @@ final class IdealUITests: XCTestCase {
             return true
         }
     }
-    
+
     func testSuccessfulIdealTransaction() {
         app.launch()
         app.swipeUp()
-        app.cellWithIdentifier(Selectors.FeatureList.paymentMethods)?.tap()
+        app.textWithIdentifier(Selectors.FeatureList.paymentMethods)?.tap()
         app.payNowButton?.tap()
         app.idealNextButton?.tap()
         app.idealLoginButton?.tap()
@@ -34,11 +34,11 @@ final class IdealUITests: XCTestCase {
         app.idealBackButton?.tap()
         app.assertIdealResultObject(app, "IDEAL", "SUCCEEDED")
     }
-    
+
     func testCancelIdealTransaction() {
         app.launch()
         app.swipeUp()
-        app.cellWithIdentifier(Selectors.FeatureList.paymentMethods)?.tap()
+        app.textWithIdentifier(Selectors.FeatureList.paymentMethods)?.tap()
         app.payNowButton?.tap()
         app.idealAbortButton?.tap()
         sleep(3)

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/Selectors.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/Selectors.swift
@@ -65,6 +65,7 @@ class Selectors {
         static let addressTwoValue = "address2 Value"
         static let townValue = "town Value"
         static let postCodeValue = "postCode Value"
+        static let paymentMethodValue = "paymentMethod Value"
     }
     struct Ideal {
         static let makePaymentButton = "Make Payment"

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/XCUIApplication+Additions.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/XCUIApplication+Additions.swift
@@ -236,21 +236,18 @@ extension XCUIApplication {
                                  expiryDate: Constants.CardDetails.cardExpiry,
                                  securityCode: Constants.CardDetails.cardSecurityCode)
     }
-    
+
     func assertIdealResultObject(_ app: XCUIApplication, _ paymentMethod: String, _ message: String) {
         let tableView = app.tables[Selectors.Other.resultsTable]
         XCTAssert(tableView.waitForExistence(timeout: 10))
-        
-        let receiptIdCell = tableView.cells.element(matching: .cell, identifier: "receiptId")
-        let receiptIdValue = receiptIdCell.staticTexts.element(boundBy: 1).label
-        XCTAssert(!receiptIdValue.isEmpty, "ReceiptId is empty")
-        
-        let paymentMethodCell = tableView.cells.element(matching: .cell, identifier: "paymentMethod")
-        let paymentMethodValue = paymentMethodCell.staticTexts.element(boundBy: 1).label
-        XCTAssertEqual(paymentMethodValue, paymentMethod, "Payment method value on result object does not match the expected string")
-        
-        let messageCell = tableView.cells.element(matching: .cell, identifier: "message")
-        let messageValue = messageCell.staticTexts.element(boundBy: 1).label
-        XCTAssertTrue(messageValue.hasPrefix(message), "Message value on result object does not start with the expected string")
+
+        let receiptIdCell = app.textWithIdentifier(Selectors.ResultsView.receiptIdValue)
+        XCTAssertFalse(receiptIdCell!.label.isEmpty, "ReceiptId is empty")
+
+        let paymentMethodCell = app.textWithIdentifier(Selectors.ResultsView.paymentMethodValue)
+        XCTAssertEqual(paymentMethodCell!.label, paymentMethod, "Payment method value on result object does not match the expected string")
+
+        let messageCell = app.textWithIdentifier(Selectors.ResultsView.messageValue)
+        XCTAssertTrue(messageCell!.label.hasPrefix(message), "Message value on result object does not start with the expected string")
     }
 }

--- a/Examples/SwiftExampleApp/SwiftExampleAppUITests/XCUIApplication+Additions.swift
+++ b/Examples/SwiftExampleApp/SwiftExampleAppUITests/XCUIApplication+Additions.swift
@@ -129,23 +129,23 @@ extension XCUIApplication {
     var fieldErrorLabel: String? {
         return textWithIdentifier(Selectors.BillingInfo.fieldErrorLabel)?.label
     }
-    
+
     var idealNextButton: XCUIElement? {
         return buttonWithLabel(Selectors.Ideal.nextButton)
     }
-    
+
     var idealLoginButton: XCUIElement? {
         return buttonWithLabel(Selectors.Ideal.loginButton)
     }
-    
+
     var idealPaymentButton: XCUIElement? {
         return buttonWithLabel(Selectors.Ideal.makePaymentButton)
     }
-    
+
     var idealBackButton: XCUIElement? {
         return buttonWithLabel(Selectors.Ideal.backButton)
     }
-    
+
     var idealAbortButton: XCUIElement? {
         return buttonWithLabel(Selectors.Ideal.abortButton)
     }
@@ -154,11 +154,11 @@ extension XCUIApplication {
         let judoID = ProcessInfo.processInfo.environment["TEST_API_JUDO_ID"]
         let apiToken = ProcessInfo.processInfo.environment["TEST_API_TOKEN"]
         let apiSecret = ProcessInfo.processInfo.environment["TEST_API_SECRET"]
-        
+
         let idealJudoID = ProcessInfo.processInfo.environment["IDEAL_JUDO_ID"]
         let idealToken = ProcessInfo.processInfo.environment["IDEAL_API_TOKEN"]
         let idealSecret = ProcessInfo.processInfo.environment["IDEAL_API_SECRET"]
-        
+
         if isIdealTest {
             launchArguments += ["-judo_id", idealJudoID ?? "",
                                 "-token", idealToken ?? "",
@@ -169,9 +169,9 @@ extension XCUIApplication {
         } else {
             launchArguments += ["-judo_id", judoID ?? "",
                                 "-token", apiToken ?? "",
-                                "-secret", apiSecret ?? "",]
+                                "-secret", apiSecret ?? ""]
         }
-        
+
         launchArguments += ["-is_sandboxed", "true",
                             "-is_token_and_secret_on", "true",
                             "-should_ask_for_billing_information", "false",


### PR DESCRIPTION
* Separate iPad and iPhone tests so re-runs take less time
* Remove 3DS2 complete button loop and replace with single wait and tap as this seems more consistent
* Fix issue where halt transaction switch is toggled off for the test
* Add labels to Firebase runs, allow 1 re-run