### PR TITLE
Small fixes for backward compatibility tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,8 +456,8 @@ jobs:
               --num-flaky-test-attempts=1 \
               --client-details=matrixLabel="Backward Compat E2E" \
               --timeout=30m
-      - notify_slack_error_weekly
-      - notify_slack_pass_weekly
+      # - notify_slack_error_weekly
+      # - notify_slack_pass_weekly
   instrumented_tests_swift_sample_iphone:
     executor: macos
     steps:
@@ -659,4 +659,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - backward-compat-test-fixes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,8 +456,8 @@ jobs:
               --num-flaky-test-attempts=1 \
               --client-details=matrixLabel="Backward Compat E2E" \
               --timeout=30m
-      # - notify_slack_error_weekly
-      # - notify_slack_pass_weekly
+      - notify_slack_error_weekly
+      - notify_slack_pass_weekly
   instrumented_tests_swift_sample_iphone:
     executor: macos
     steps:
@@ -659,4 +659,4 @@ workflows:
           filters:
             branches:
               only:
-                - backward-compat-test-fixes
+                - master

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
@@ -158,9 +158,28 @@ func assertNoRequestToJudoAPI(_ app: XCUIApplication) {
 }
 
 func toggleHaltTransactionSwitchIfOff(_ app: XCUIApplication) {
+    scrollToElement(element: app.haltTransactionSwitch!)
     if app.haltTransactionSwitchValue == "0" {
         app.haltTransactionSwitch?.tap()
     } else {
         print("Switch not found")
     }
+}
+
+func scrollToElement(element: XCUIElement, maxScrolls: Int = 10) {
+    var scrollCount = 0
+
+    while !element.isHittable && scrollCount < maxScrolls {
+        XCUIApplication().swipeUp()
+        scrollCount += 1
+    }
+    
+    if !element.isHittable {
+        print("Element not found after \(maxScrolls) scrolls")
+    }
+}
+
+func waitForElementToBeHittable(element: XCUIElement, timeout: TimeInterval = 10) -> Bool {
+    let exists = element.waitForExistence(timeout: timeout)
+    return exists && element.isHittable
 }

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Additions/Helpers.swift
@@ -183,3 +183,11 @@ func waitForElementToBeHittable(element: XCUIElement, timeout: TimeInterval = 10
     let exists = element.waitForExistence(timeout: timeout)
     return exists && element.isHittable
 }
+
+func tapPayNowButton(_ app: XCUIApplication) {
+    if waitForElementToBeHittable(element: app.cardDetailsSubmitButton!) {
+        app.cardDetailsSubmitButton?.tap()
+    } else {
+        XCTFail("Pay now button is not hittable")
+    }
+}

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/CardPayment/CardPaymentUITests.swift
@@ -48,7 +48,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "AuthCode: ", "Success")
     }
@@ -60,7 +60,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: "123")
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "Card declined: Additional customer authentication required", "Declined")
     }
@@ -72,7 +72,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: "123")
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "The gateway reported an error", "Error")
     }
@@ -84,7 +84,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         let cancelButton = app.buttons["Cancel"]
         XCTAssert(cancelButton.waitForExistence(timeout: 10))
         app.cancelButton3DS2?.tap()
@@ -97,7 +97,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "PreAuth", "AuthCode: ", "Success")
     }
@@ -109,7 +109,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Register", "AuthCode: ", "Success")
     }
@@ -121,7 +121,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "CheckCard", "AuthCode: ", "Success")
     }
@@ -135,10 +135,10 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.tokenPaymentButton?.tap()
         app.securityCodeTextField?.tapAndTypeText(TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "AuthCode: ", "Success")
     }
@@ -152,10 +152,10 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.tokenPreauthButton?.tap()
         app.securityCodeTextField?.tapAndTypeText(TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "PreAuth", "AuthCode: ", "Success")
     }
@@ -168,7 +168,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: "Frictionless Successful",
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertResultObject(app, "Payment", "AuthCode: ", "Success")
     }
     
@@ -180,7 +180,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: "Frictionless NoMethod",
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertResultObject(app, "Payment", "AuthCode: ", "Success")
     }
     
@@ -192,7 +192,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: "Frictionless AuthFailed",
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
     }
     
     func testSuccessfulPaymentMethodsCardPayment() {
@@ -205,10 +205,10 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.payNowButton?.tap()
         app.securityCodeTextField?.tapAndTypeText(TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "AuthCode: ", "Success")
     }
@@ -223,10 +223,10 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.payNowButton?.tap()
         app.securityCodeTextField?.tapAndTypeText(TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "PreAuth", "AuthCode: ", "Success")
     }
@@ -239,7 +239,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         let newCard = app.staticTexts["Visa Ending 7408 "]
         XCTAssert(newCard.waitForExistence(timeout: 5), "Unable to add a new card")
         newCard.swipeLeft()
@@ -258,7 +258,7 @@ final class CardPaymentUITests: XCTestCase {
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
         XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.fillBillingInfoDetails(email: TestData.BillingInfo.VALID_EMAIL,
                                    phone: TestData.BillingInfo.VALID_MOBILE,
                                    addressOne: TestData.BillingInfo.VALID_ADDRESS,
@@ -266,7 +266,7 @@ final class CardPaymentUITests: XCTestCase {
                                    city: TestData.BillingInfo.VALID_CITY,
                                    postCode: TestData.BillingInfo.VALID_POSTCODE)
         XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "AuthCode: ", "Success")
         assertBillingInfo(app, TestData.BillingInfo.VALID_COUNTRY_CODE, TestData.BillingInfo.VALID_CITY, TestData.BillingInfo.VALID_ADDRESS, TestData.BillingInfo.VALID_ADDRESS_TWO, TestData.BillingInfo.VALID_POSTCODE)
@@ -281,7 +281,7 @@ final class CardPaymentUITests: XCTestCase {
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
         XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.fillBillingInfoDetails(email: TestData.BillingInfo.VALID_EMAIL,
                                    phone: TestData.BillingInfo.VALID_MOBILE,
                                    addressOne: TestData.BillingInfo.VALID_ADDRESS,
@@ -305,7 +305,7 @@ final class CardPaymentUITests: XCTestCase {
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
         XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.countryField?.tap()
         app.pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "United States")
         app.stateField?.tap()
@@ -334,7 +334,7 @@ final class CardPaymentUITests: XCTestCase {
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
         XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         app.countryField?.tap()
         app.pickerWheels.element(boundBy: 0).adjust(toPickerWheelValue: "Canada")
         app.stateField?.tap()
@@ -359,7 +359,7 @@ final class CardPaymentUITests: XCTestCase {
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
         XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         
         app.emailField?.tapAndTypeText(TestData.BillingInfo.SPECIAL_CHARACTERS)
         app.addressLineOne?.tap()
@@ -400,7 +400,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: "Frictionless Successful",
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.WRONG_CV2)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "Payment", "Card declined: CV2 policy", "Declined")
     }
@@ -413,7 +413,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: "Frictionless Successful",
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.WRONG_CV2)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertResultObject(app, "PreAuth", "Card declined: CV2 policy", "Declined")
     }
@@ -426,7 +426,7 @@ final class CardPaymentUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertPADSent(app)
     }

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Ideal/IdealUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Ideal/IdealUITests.swift
@@ -28,6 +28,7 @@ final class IdealUITests: XCTestCase {
         app.swipeUp()
         app.cellWithIdentifier(Selectors.FeatureList.paymentMethods)?.tap()
         app.payNowButton?.tap()
+        sleep(3)
         app.idealNextButton?.tap()
         app.idealLoginButton?.tap()
         app.idealPaymentButton?.tap()
@@ -40,6 +41,8 @@ final class IdealUITests: XCTestCase {
         app.swipeUp()
         app.cellWithIdentifier(Selectors.FeatureList.paymentMethods)?.tap()
         app.payNowButton?.tap()
+        sleep(3)
+        scrollToElement(element: app.idealAbortButton!)
         app.idealAbortButton?.tap()
         sleep(3)
         let snackbar = app.staticTexts[TestData.Other.IDEAL_CANCELLED_PAYMENT_ALERT]

--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Ravelin/RavelinUITests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Ravelin/RavelinUITests.swift
@@ -33,7 +33,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertNoRequestToJudoAPI(app)
     }
     
@@ -45,7 +45,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.CHALLENGE_PREFERRED, sca: TestData.Ravelin.LOW_VALUE)
     }
@@ -58,7 +58,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.NO_PREFERENCE, sca: TestData.Ravelin.TRA)
     }
     
@@ -70,7 +70,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.NO_CHALLENGE, sca: TestData.Ravelin.LOW_VALUE)
     }
     
@@ -82,7 +82,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.CHALLENGE_MANDATE, sca: TestData.Ravelin.LOW_VALUE)
     }
@@ -95,7 +95,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.CHALLENGE_MANDATE, sca: TestData.Ravelin.LOW_VALUE, criShouldExist: false)
     }
     
@@ -107,7 +107,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.NO_CHALLENGE, sca: TestData.Ravelin.TRA, scaShouldExist: false)
     }
     
@@ -119,7 +119,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.NO_CHALLENGE, sca: TestData.Ravelin.TRA, criShouldExist: false, scaShouldExist: false)
     }
@@ -132,7 +132,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         tapCompleteButton(app)
         assertRequestBody(app, cri: TestData.Ravelin.NO_CHALLENGE, sca: TestData.Ravelin.TRA, criShouldExist: false, scaShouldExist: false)
     }
@@ -160,7 +160,7 @@ final class RavelinUITests: XCTestCase {
                              cardHolder: TestData.CardDetails.CARDHOLDER_NAME,
                              expiryDate: TestData.CardDetails.CARD_EXPIRY,
                              securityCode: TestData.CardDetails.CARD_SECURITY_CODE)
-        app.cardDetailsSubmitButton?.tap()
+        tapPayNowButton(app)
         sleep(3)
         assertNoRequestToJudoAPI(app)
     }


### PR DESCRIPTION
* Scroll to element before trying to tap (for smaller screen on iPhone 8)
* Wait until element is hittable for pay now button