### PR TITLE
Firebase test device updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 16.2 \
-              --device model=iphone15,version=18.0 \
+              --device model=ipad10,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPad)" \
               --timeout=30m \
@@ -511,7 +511,7 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/SwiftExampleAppUITests.zip \
               --xcode-version 16.2 \
-              --device model=iphone15,version=18.0 \
+              --device model=ipad10,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPad)" \
               --num-flaky-test-attempts=1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
           command: >
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
-              --xcode-version 15.3 \
+              --xcode-version 16.2 \
               --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
@@ -426,7 +426,7 @@ jobs:
           command: >
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
-              --xcode-version 15.3 \
+              --xcode-version 16.2 \
               --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPad)" \
@@ -481,7 +481,7 @@ jobs:
           command: >
             gcloud firebase test ios run \
               --test ./Output/SwiftExampleAppUITests.zip \
-              --xcode-version 15.3 \
+              --xcode-version 16.2 \
               --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
@@ -509,7 +509,7 @@ jobs:
           command: >
             gcloud firebase test ios run \
               --test ./Output/SwiftExampleAppUITests.zip \
-              --xcode-version 15.3 \
+              --xcode-version 16.2 \
               --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPad)" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,13 +399,13 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 15.3 \
-              --device model=iphone14pro,version=16.6 \
+              --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --timeout=30m \
               --num-flaky-test-attempts=1 \
-      - notify_slack_error
-      - notify_slack_pass
+      # - notify_slack_error
+      # - notify_slack_pass
   instrumented_tests_sample_ipad:
     executor: macos
     steps:
@@ -427,7 +427,7 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 15.3 \
-              --device model=ipad10,version=16.6 \
+              --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPad)" \
               --timeout=30m \
@@ -482,13 +482,13 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/SwiftExampleAppUITests.zip \
               --xcode-version 15.3 \
-              --device model=iphone14pro,version=16.6 \
+              --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --num-flaky-test-attempts=1 \
               --timeout=30m
-      - notify_slack_error
-      - notify_slack_pass
+      # - notify_slack_error
+      # - notify_slack_pass
   instrumented_tests_swift_sample_ipad:
     executor: macos
     steps:
@@ -510,7 +510,7 @@ jobs:
             gcloud firebase test ios run \
               --test ./Output/SwiftExampleAppUITests.zip \
               --xcode-version 15.3 \
-              --device model=ipad10,version=16.6 \
+              --device model=iphone15,version=18.0 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --client-details=matrixLabel="Regression E2E (iPad)" \
               --num-flaky-test-attempts=1 \
@@ -594,7 +594,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - firebase-test-device-updates
       - instrumented_tests_sample_ipad:
           context: shared-secrets
           requires:
@@ -602,7 +602,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - firebase-test-device-updates
       - build_instrumented_tests_swift_package:
           requires:
             - unit_test_sdk
@@ -613,7 +613,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - firebase-test-device-updates
       - instrumented_tests_swift_sample_ipad:
           context: shared-secrets
           requires:
@@ -621,7 +621,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - firebase-test-device-updates
       - release_sample:
           context: shared-secrets
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,8 +404,8 @@ jobs:
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --timeout=30m \
               --num-flaky-test-attempts=1 \
-      # - notify_slack_error
-      # - notify_slack_pass
+      - notify_slack_error
+      - notify_slack_pass
   instrumented_tests_sample_ipad:
     executor: macos
     steps:
@@ -452,9 +452,10 @@ jobs:
           command: >
             gcloud firebase test ios run \
               --test ./Output/ObjectiveCExampleAppUITests.zip \
-              --xcode-version 15.3 \
+              --xcode-version 16.2 \
               --device model=iphone8,version=15.7 \
               --device model=iphone12pro,version=14.8 \
+              --device model=iphone14pro,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --num-flaky-test-attempts=1 \
               --client-details=matrixLabel="Backward Compat E2E" \
@@ -487,8 +488,8 @@ jobs:
               --client-details=matrixLabel="Regression E2E (iPhone)" \
               --num-flaky-test-attempts=1 \
               --timeout=30m
-      # - notify_slack_error
-      # - notify_slack_pass
+      - notify_slack_error
+      - notify_slack_pass
   instrumented_tests_swift_sample_ipad:
     executor: macos
     steps:
@@ -594,7 +595,7 @@ workflows:
           filters:
             branches:
               only:
-                - firebase-test-device-updates
+                - master
       - instrumented_tests_sample_ipad:
           context: shared-secrets
           requires:
@@ -602,7 +603,7 @@ workflows:
           filters:
             branches:
               only:
-                - firebase-test-device-updates
+                - master
       - build_instrumented_tests_swift_package:
           requires:
             - unit_test_sdk
@@ -613,7 +614,7 @@ workflows:
           filters:
             branches:
               only:
-                - firebase-test-device-updates
+                - master
       - instrumented_tests_swift_sample_ipad:
           context: shared-secrets
           requires:
@@ -621,7 +622,7 @@ workflows:
           filters:
             branches:
               only:
-                - firebase-test-device-updates
+                - master
       - release_sample:
           context: shared-secrets
           requires:


### PR DESCRIPTION
* Firebase has now introduced an iOS 18 test device built with XCode 16.2 (finally!) so switching to use this for regular regression tests on iPhone. These seem to be slightly faster too (~17mins vs ~24mins).
* Added previously used iOS 16.6 device to the backward compatibility device pool
* Updated for all tests to use XCode 16.2