### PR TITLE
Remove deprecated Firebase test device

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,6 @@ jobs:
               --test ./Output/ObjectiveCExampleAppUITests.zip \
               --xcode-version 16.2 \
               --device model=iphone8,version=15.7 \
-              --device model=iphone12pro,version=14.8 \
               --device model=iphone14pro,version=16.6 \
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --num-flaky-test-attempts=1 \


### PR DESCRIPTION
* iPhone 12 Pro and iOS 14.8 are no longer available so removing this for backward compatibility tests