### PR TITLE
chore: fix workflow names

### DIFF
--- a/.github/workflows/build-test-publish-sample-apps.yml
+++ b/.github/workflows/build-test-publish-sample-apps.yml
@@ -13,12 +13,12 @@ jobs:
     needs: build_and_test_sample_apps
     secrets: inherit
   test_sample_apps_firebase:
-    uses: Judopay/github-actions/.github/workflows/ios-test-sample-apps-firebase.yml@master
+    uses: Judopay/github-actions/.github/workflows/test-sample-apps-firebase.yml@master
     needs: publish_sample_apps
     secrets: inherit
     with:
       firebase_matrix_label: 'Merge to master'
   test_sample_apps_browserstack:
-    uses: Judopay/github-actions/.github/workflows/ios-test-sample-apps-browserstack.yml@master
+    uses: Judopay/github-actions/.github/workflows/test-sample-apps-browserstack.yml@master
     needs: publish_sample_apps
     secrets: inherit


### PR DESCRIPTION
These workflow names have been changed as they are no longer platform specific.