### PR TITLE
CT-3223 | Standardise selectors in prep for Maestro

### DIFF
--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp/Controllers/Main/MainViewController.m
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleApp/Controllers/Main/MainViewController.m
@@ -65,7 +65,7 @@ static NSString *const kNoUIPaymentsScreenSegue = @"noUIPayments";
     
     // Setup accessibility identifiers
     self.view.accessibilityIdentifier = @"Main View";
-    self.settingsButton.accessibilityIdentifier = @"Settings Button";
+    self.settingsButton.accessibilityIdentifier = @"settings_button";
     self.networkInspectorButton.accessibilityIdentifier = @"Network requests inspector button";
     self.networkInspectorButton.action = @selector(presentNetworkRequestsInspector);
     self.networkInspectorButton.target = self;

--- a/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
+++ b/Source/Modules/PaymentMethods/View/JPPaymentMethodsViewController.m
@@ -97,7 +97,7 @@
     self.navigationController.navigationBar.translucent = YES;
 
     UIButton *backButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    backButton.accessibilityIdentifier = @"Back Button";
+    backButton.accessibilityIdentifier = @"back_button";
     backButton.imageView.contentMode = UIViewContentModeScaleAspectFit;
 
     UIImage *defaultIcon = [UIImage _jp_imageWithIconName:@"back-icon"];

--- a/Source/Modules/PaymentMethods/View/Subviews/Cells/PaymentMethodSelectionCell/JPPaymentMethodsSelectionCell.m
+++ b/Source/Modules/PaymentMethods/View/Subviews/Cells/PaymentMethodSelectionCell/JPPaymentMethodsSelectionCell.m
@@ -90,11 +90,11 @@ static const int kConstraintPriority = 999;
 
         switch (paymentMethod.type) {
             case JPPaymentMethodTypeCard:
-                section.accessibilityIdentifier = @"Card Selector View";
+                section.accessibilityIdentifier = @"card_selector_view";
                 break;
 
             case JPPaymentMethodTypeApplePay:
-                section.accessibilityIdentifier = @"Apple Pay Selector View";
+                section.accessibilityIdentifier = @"apple_pay_selector_view";
         }
 
         [sections addObject:section];

--- a/Source/View/CardInputView/Subviews/ActionBar/JPActionBar.m
+++ b/Source/View/CardInputView/Subviews/ActionBar/JPActionBar.m
@@ -79,14 +79,14 @@ static const float kMaxTopBarButtonTextSize = 28.0F;
     self.backButton = [JPTransactionButton buttonWithType:UIButtonTypeSystem];
     self.backButton.contentEdgeInsets = UIEdgeInsetsMake(0, 30, 0, 30);
     self.backButton.translatesAutoresizingMaskIntoConstraints = NO;
-    self.backButton.accessibilityIdentifier = @"Back Button";
+    self.backButton.accessibilityIdentifier = @"back_button";
     self.backButton.clipsToBounds = YES;
     self.backButton.titleLabel.numberOfLines = 1;
     self.backButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
 
     self.submitButton = [JPTransactionButton new];
     self.submitButton.translatesAutoresizingMaskIntoConstraints = NO;
-    self.submitButton.accessibilityIdentifier = @"Submit Button";
+    self.submitButton.accessibilityIdentifier = @"submit_button";
     self.submitButton.clipsToBounds = YES;
     self.submitButton.titleLabel.numberOfLines = 1;
     self.submitButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;

--- a/Source/View/CardInputView/Subviews/JPBillingInformationForm.m
+++ b/Source/View/CardInputView/Subviews/JPBillingInformationForm.m
@@ -82,7 +82,7 @@ static const float kButtonContentPadding = 16.0F;
     self.headingLabel.numberOfLines = 0;
 
     self.emailTextField = [JPCardInputField new];
-    self.emailTextField.accessibilityIdentifier = @"Cardholder Email Field";
+    self.emailTextField.accessibilityIdentifier = @"cardholder_email_field";
     self.emailTextField.keyboardType = UIKeyboardTypeEmailAddress;
     self.emailTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     self.emailTextField.textContentType = UITextContentTypeEmailAddress;
@@ -90,33 +90,33 @@ static const float kButtonContentPadding = 16.0F;
     self.countryPickerView = [UIPickerView new];
     self.countryPickerView.delegate = self;
     self.countryPickerView.dataSource = self;
-    self.countryPickerView.accessibilityIdentifier = @"Country Picker";
+    self.countryPickerView.accessibilityIdentifier = @"country_picker";
 
     self.administrativeDivisionPickerView = [UIPickerView new];
     self.administrativeDivisionPickerView.delegate = self;
     self.administrativeDivisionPickerView.dataSource = self;
-    self.administrativeDivisionPickerView.accessibilityIdentifier = @"Administrative Division Picker";
+    self.administrativeDivisionPickerView.accessibilityIdentifier = @"administrative_division_picker";
 
     self.countryTextField = [JPCardInputField new];
     self.countryTextField.inputView = self.countryPickerView;
-    self.countryTextField.accessibilityIdentifier = @"Country Field";
+    self.countryTextField.accessibilityIdentifier = @"country_field";
     self.countryTextField.textContentType = UITextContentTypeCountryName;
 
     self.administrativeDivisionTextField = [JPCardInputField new];
     self.administrativeDivisionTextField.inputView = self.administrativeDivisionPickerView;
-    self.administrativeDivisionTextField.accessibilityIdentifier = @"Administrative Division Field";
+    self.administrativeDivisionTextField.accessibilityIdentifier = @"administrative_division_field";
     self.administrativeDivisionTextField.hidden = YES;
     self.administrativeDivisionTextField.textContentType = UITextContentTypeAddressState;
 
     self.phoneCodeTextField = [JPPhoneCodeInputField new];
-    self.phoneCodeTextField.accessibilityIdentifier = @"Cardholder phone code Field";
+    self.phoneCodeTextField.accessibilityIdentifier = @"cardholder_phone_code_field";
     self.phoneCodeTextField.keyboardType = UIKeyboardTypeNumberPad;
     self.phoneCodeTextField.backgroundMaskedCorners = kCALayerMinXMinYCorner | kCALayerMinXMaxYCorner;
     [self.phoneCodeTextField setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
     [self.phoneCodeTextField setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
 
     self.phoneTextField = [JPCardInputField new];
-    self.phoneTextField.accessibilityIdentifier = @"Cardholder phone number Field";
+    self.phoneTextField.accessibilityIdentifier = @"cardholder_phone_number_field";
     self.phoneTextField.keyboardType = UIKeyboardTypeNumberPad;
     self.phoneTextField.backgroundMaskedCorners = kCALayerMaxXMinYCorner | kCALayerMaxXMaxYCorner;
     self.phoneTextField.textContentType = UITextContentTypeTelephoneNumber;
@@ -124,7 +124,7 @@ static const float kButtonContentPadding = 16.0F;
     [self.phoneTextField setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 
     self.line1TextField = [JPCardInputField new];
-    self.line1TextField.accessibilityIdentifier = @"Cardholder address line 1 code Field";
+    self.line1TextField.accessibilityIdentifier = @"cardholder_address_line_1_field";
     self.line1TextField.keyboardType = UIKeyboardTypeDefault;
     self.line1TextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
     self.line1TextField.textContentType = UITextContentTypeStreetAddressLine1;
@@ -132,7 +132,7 @@ static const float kButtonContentPadding = 16.0F;
     self.addAddressLineButton = [JPTransactionButton buttonWithType:UIButtonTypeSystem];
     self.addAddressLineButton.translatesAutoresizingMaskIntoConstraints = NO;
     self.addAddressLineButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
-    self.addAddressLineButton.accessibilityIdentifier = @"Add address line Button";
+    self.addAddressLineButton.accessibilityIdentifier = @"add_address_line_button";
     self.addAddressLineButton.titleLabel.numberOfLines = 0;
     self.addAddressLineButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
     [self.addAddressLineButton setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
@@ -143,27 +143,27 @@ static const float kButtonContentPadding = 16.0F;
     [self.addAddressLineButton setTitle:title forState:UIControlStateNormal];
 
     self.line2TextField = [JPCardInputField new];
-    self.line2TextField.accessibilityIdentifier = @"Cardholder address line 2 Field";
+    self.line2TextField.accessibilityIdentifier = @"cardholder_address_line_2_field";
     self.line2TextField.keyboardType = UIKeyboardTypeDefault;
     self.line2TextField.hidden = YES;
     self.line2TextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
     self.line2TextField.textContentType = UITextContentTypeStreetAddressLine2;
 
     self.line3TextField = [JPCardInputField new];
-    self.line3TextField.accessibilityIdentifier = @"Cardholder address line 3 Field";
+    self.line3TextField.accessibilityIdentifier = @"cardholder_address_line_3_field";
     self.line3TextField.keyboardType = UIKeyboardTypeDefault;
     self.line3TextField.hidden = YES;
     self.line3TextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
 
     self.cityTextField = [JPCardInputField new];
-    self.cityTextField.accessibilityIdentifier = @"Cardholder city Field";
+    self.cityTextField.accessibilityIdentifier = @"cardholder_city_field";
     self.cityTextField.keyboardType = UIKeyboardTypeDefault;
     self.cityTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
     self.cityTextField.textContentType = UITextContentTypeAddressCity;
 
     self.postcodeTextField = [JPCardInputField new];
     self.postcodeTextField.keyboardType = UIKeyboardTypeDefault;
-    self.postcodeTextField.accessibilityIdentifier = @"Post Code Field";
+    self.postcodeTextField.accessibilityIdentifier = @"post_code_field";
     self.postcodeTextField.textContentType = UITextContentTypePostalCode;
 
     UIStackView *phoneNumberStackView = [UIStackView _jp_horizontalStackViewWithSpacing:kSeparatorContentSpacing

--- a/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
+++ b/Source/View/CardInputView/Subviews/JPCardDetailsForm.m
@@ -205,7 +205,7 @@ static const float kTightContentSpacing = 8.0F;
 - (JPCardNumberField *)cardNumberTextField {
     if (!_cardNumberTextField) {
         _cardNumberTextField = [JPCardNumberField new];
-        _cardNumberTextField.accessibilityIdentifier = @"Card Number Field";
+        _cardNumberTextField.accessibilityIdentifier = @"card_number";
         _cardNumberTextField.keyboardType = UIKeyboardTypeNumberPad;
         _cardNumberTextField.textContentType = UITextContentTypeCreditCardNumber;
         _cardNumberTextField.delegate = self.inputFieldDelegate;
@@ -216,7 +216,7 @@ static const float kTightContentSpacing = 8.0F;
 - (JPCardInputField *)cardHolderNameTextField {
     if (!_cardHolderNameTextField) {
         _cardHolderNameTextField = [JPCardInputField new];
-        _cardHolderNameTextField.accessibilityIdentifier = @"Cardholder Name Field";
+        _cardHolderNameTextField.accessibilityIdentifier = @"cardholder_name";
         _cardHolderNameTextField.keyboardType = UIKeyboardTypeDefault;
         _cardHolderNameTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
 
@@ -235,7 +235,7 @@ static const float kTightContentSpacing = 8.0F;
 - (JPCardInputField *)expiryDateTextField {
     if (!_expiryDateTextField) {
         _expiryDateTextField = [JPCardInputField new];
-        _expiryDateTextField.accessibilityIdentifier = @"Expiry Date Field";
+        _expiryDateTextField.accessibilityIdentifier = @"expiry_date";
         _expiryDateTextField.keyboardType = UIKeyboardTypeNumberPad;
 
 // TODO: Remove after April 2024
@@ -253,7 +253,7 @@ static const float kTightContentSpacing = 8.0F;
 - (JPCardInputField *)cardSecurityCodeTextField {
     if (!_cardSecurityCodeTextField) {
         _cardSecurityCodeTextField = [JPCardInputField new];
-        _cardSecurityCodeTextField.accessibilityIdentifier = @"Security Code Field";
+        _cardSecurityCodeTextField.accessibilityIdentifier = @"security_code";
         _cardSecurityCodeTextField.keyboardType = UIKeyboardTypeNumberPad;
 
 // TODO: Remove after April 2024
@@ -272,7 +272,7 @@ static const float kTightContentSpacing = 8.0F;
     if (!_countryTextField) {
         _countryTextField = [JPCardInputField new];
         _countryTextField.inputView = self.countryPickerView;
-        _countryTextField.accessibilityIdentifier = @"Country Field";
+        _countryTextField.accessibilityIdentifier = @"country_field";
         _countryTextField.textContentType = UITextContentTypeCountryName;
         _countryTextField.delegate = self.inputFieldDelegate;
     }
@@ -283,7 +283,7 @@ static const float kTightContentSpacing = 8.0F;
     if (!_postcodeTextField) {
         _postcodeTextField = [JPCardInputField new];
         _postcodeTextField.keyboardType = UIKeyboardTypeDefault;
-        _postcodeTextField.accessibilityIdentifier = @"Post Code Field";
+        _postcodeTextField.accessibilityIdentifier = @"postcode_field";
         _postcodeTextField.textContentType = UITextContentTypePostalCode;
         _postcodeTextField.delegate = self.inputFieldDelegate;
     }
@@ -293,7 +293,7 @@ static const float kTightContentSpacing = 8.0F;
 - (UIPickerView *)countryPickerView {
     if (!_countryPickerView) {
         _countryPickerView = [UIPickerView new];
-        _countryPickerView.accessibilityIdentifier = @"Country Picker";
+        _countryPickerView.accessibilityIdentifier = @"country_picker";
         _countryPickerView.delegate = self;
         _countryPickerView.dataSource = self;
     }

--- a/Source/View/TextInputLayout/JPTextInputLayout.m
+++ b/Source/View/TextInputLayout/JPTextInputLayout.m
@@ -156,7 +156,7 @@ static const float kPrefferedCompressedHeight = 40.0F;
         _floatingLabel.hidden = YES;
 
         _floatingLabel.isAccessibilityElement = YES;
-        _floatingLabel.accessibilityIdentifier = @"Error Floating Label";
+        _floatingLabel.accessibilityIdentifier = @"error_floating_label";
     }
     return _floatingLabel;
 }


### PR DESCRIPTION
* Use the same selectors across all our SDKs in prep for migrating tests to use Maestro framework