### PR TITLE
Remove unsupported test

### DIFF
--- a/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Fabrick3DS/Fabrick3DSTests.swift
+++ b/Examples/ObjectiveCExampleApp/ObjectiveCExampleAppUITests/Fabrick3DS/Fabrick3DSTests.swift
@@ -37,17 +37,4 @@ final class Fabrick3DSTests: XCTestCase {
         tapCompleteButton(app, true)
         assertResultObject(app, "Payment", "AuthCode: ", "Success", true)
     }
-    
-    func testFabrickMCFrictionlessFlow() {
-        app.launchArguments += ["-is_using_fabrick_3ds_service", "true", "-is_sandboxed", "false", "-challenge_request_indicator", "noPreference"]
-        app.launch()
-        app.cellWithIdentifier(Selectors.FeatureList.payWithCard)?.tap()
-        app.fillCardSheetDetails(cardNumber: TestData.CardDetails.cardNumber,
-                             cardHolder: TestData.CardDetails.frictionlessCardholder,
-                             expiryDate: TestData.CardDetails.cardExpiry,
-                             securityCode: TestData.CardDetails.cardSecurityCode)
-        XCTAssertTrue(app.cardDetailsSubmitButton!.isEnabled)
-        tapCardDetailsPayNowButton(app)
-        assertResultObject(app, "Payment", "AuthCode: ", "Success", true)
-    }
 }


### PR DESCRIPTION
Due to some changes in the backend logic, we no longer support frictionless transactions through Fabrick 3DS2